### PR TITLE
Set stage prefix for shared accounts and determine api url

### DIFF
--- a/.circleci/circle-lock.sh
+++ b/.circleci/circle-lock.sh
@@ -75,7 +75,7 @@ if [[ "$0" != *bats* ]]; then
     tag=""
     job_name=""
     rest=()
-    circle_base_url=`${CIRCLE_BUILD_URL##https://} | cut -d/ -f1`
+    circle_base_url=`echo ${CIRCLE_BUILD_URL##https://} | cut -d/ -f1`
     api_url="https://$circle_base_url/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
 
     parse_args "$@"

--- a/.circleci/circle-lock.sh
+++ b/.circleci/circle-lock.sh
@@ -75,7 +75,8 @@ if [[ "$0" != *bats* ]]; then
     tag=""
     job_name=""
     rest=()
-    api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
+    circle_base_url=`${CIRCLE_BUILD_URL##https://} | cut -d/ -f1`
+    api_url="https://$circle_base_url/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
 
     parse_args "$@"
     commit_message=$(git log -1 --pretty=%B)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,14 @@ jobs:
           name: deploy
           no_output_timeout: 30m
           command: |
-            ./deploy.sh $CIRCLE_BRANCH
+            # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
+            # This can optionally be set as an environment variable in the CircleCI Project Settings
+            ./deploy.sh $STAGE_PREFIX$CIRCLE_BRANCH
       - run:
           name: Print the application endpoint
           command: |
             cd services
-            ./output.sh ui CloudFrontEndpointUrl $CIRCLE_BRANCH
+            ./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH
 
 workflows:
   version: 2


### PR DESCRIPTION
When deploying more than one of these projects to a single account, we need to qualify the stage name.
STAGE_PREFIX set at the project settings level accomplishes that.

Also including an update to the lock script to dynamically figure out the circle ci api url