### PR TITLE
Add Smoke Tests

### DIFF
--- a/.circleci/circle-lock.sh
+++ b/.circleci/circle-lock.sh
@@ -75,7 +75,8 @@ if [[ "$0" != *bats* ]]; then
     tag=""
     job_name=""
     rest=()
-    api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
+    circle_base_url=`echo ${CIRCLE_BUILD_URL##https://} | cut -d/ -f1`
+    api_url="https://$circle_base_url/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
 
     parse_args "$@"
     commit_message=$(git log -1 --pretty=%B)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             popd
             ./test.sh
       - store_test_results:
-          path: testcafe/testcafe_results
+          path: tests/testcafe/testcafe_results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ master_and_cci_only: &master_and_cci_only
         - master
         - /^cci-[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
 
+orbs:
+  browser-tools: circleci/browser-tools
+  
 jobs:
   lock:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: Run TestCafe suite
           command: |
-            npm install -g testcafe
+            sudo npm install -g testcafe
             cd services
             export APPLICATION_ENDPOINT=`./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH`
             cd ../tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: Run TestCafe suite
           command: |
-            sudo npm install -g testcafe
+            sudo npm install -g testcafe serverless
             cd services
             export APPLICATION_ENDPOINT=`./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH`
             cd ../tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,15 @@ jobs:
           command: |
             cd services
             ./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH
+  test:
+    docker:
+      - image: circleci/node:jessie-browsers
+        environment:
+          TERM: xterm
+    steps:
+      - checkout
+      - run: ls -la
+
 
 workflows:
   version: 2
@@ -59,4 +68,8 @@ workflows:
       - deploy:
           requires:
             - lock
+          <<: *master_and_cci_only
+      - test:
+          requires:
+            - deploy
           <<: *master_and_cci_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,13 @@ jobs:
         environment:
           TERM: xterm
     steps:
-      - run: ls -la
+      - run:
+          name: Run TestCafe suite
+          command: |
+            cd services
+            export APPLICATION_ENDPOINT=`./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH`
+            cd ../tests
+            testcafe "chrome:headless" testcafe/**/*.js
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,14 @@ jobs:
           name: deploy
           no_output_timeout: 30m
           command: |
-            ./deploy.sh $CIRCLE_BRANCH
+            # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
+            # This can optionally be set as an environment variable in the CircleCI Project Settings
+            ./deploy.sh $STAGE_PREFIX$CIRCLE_BRANCH
       - run:
           name: Print the application endpoint
           command: |
             cd services
-            ./output.sh ui CloudFrontEndpointUrl $CIRCLE_BRANCH
+            ./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: |
             # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
             # This can optionally be set as an environment variable in the CircleCI Project Settings
-            ./deploy.sh $STAGE_PREFIX$CIRCLE_BRANCH
+            #./deploy.sh $STAGE_PREFIX$CIRCLE_BRANCH
       - run:
           name: Print the application endpoint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
         environment:
           TERM: xterm
     steps:
+      - checkout
       - run:
           name: Run TestCafe suite
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: circleci/node:12
     steps:
+      - checkout
       - run:
           name: lock this branch to prevent concurrent builds
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,14 @@
 version: 2.0
 
 jobs:
+  lock:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - run:
+          name: lock this branch to prevent concurrent builds
+          command: asdf
+            ./.circleci/circle-lock.sh --branch $CIRCLE_BRANCH
   deploy:
     docker:
       - image: circleci/node:12
@@ -18,10 +26,6 @@ jobs:
             echo "export INFRASTRUCTURE_TYPE=\$${CIRCLE_BRANCH//-/_}_INFRASTRUCTURE_TYPE" >> $BASH_ENV
       - run: sudo npm install -g serverless
       - run:
-          name: lock this branch to prevent concurrent builds
-          command: |
-            ./.circleci/circle-lock.sh --branch $CIRCLE_BRANCH
-      - run:
           name: deploy
           no_output_timeout: 30m
           command: |
@@ -38,7 +42,15 @@ workflows:
   version: 2
   deploy:
     jobs:
+      - lock:
+          filters:
+            branches:
+              only:
+                - master
+                - /^cci-[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
       - deploy:
+          requires:
+            - lock
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: Run TestCafe suite
           command: |
-            sudo npm install -g testcafe serverless
+            sudo npm install -g testcafe serverless testcafe-reporter-junit
             pushd services
             export APPLICATION_ENDPOINT=`./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH`
             popd

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
       - run:
           name: Run TestCafe suite
           command: |
+            npm install -g testcafe
             cd services
             export APPLICATION_ENDPOINT=`./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH`
             cd ../tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ master_and_cci_only: &master_and_cci_only
         - master
         - /^cci-[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
 
-orbs:
-  browser-tools: circleci/browser-tools@1.0.1
-
 jobs:
   lock:
     docker:
@@ -52,16 +49,6 @@ jobs:
           command: |
             cd services
             ./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH
-  test:
-    docker:
-      - image: circleci/node:12
-        environment:
-          TERM: xterm
-    steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
-      - checkout
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - run:
           name: lock this branch to prevent concurrent builds
-          command: asdf
+          command: |
             ./.circleci/circle-lock.sh --branch $CIRCLE_BRANCH
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: |
             # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.
             # This can optionally be set as an environment variable in the CircleCI Project Settings
-            #./deploy.sh $STAGE_PREFIX$CIRCLE_BRANCH
+            ./deploy.sh $STAGE_PREFIX$CIRCLE_BRANCH
       - run:
           name: Print the application endpoint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,18 @@
 version: 2.0
 
+master_and_cci_only: &master_and_cci_only
+  filters:
+    branches:
+      only:
+        - master
+        - /^cci-[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
+
 jobs:
   lock:
     docker:
       - image: circleci/node:12
+        environment:
+          TERM: xterm
     steps:
       - checkout
       - run:
@@ -13,6 +22,8 @@ jobs:
   deploy:
     docker:
       - image: circleci/node:12
+        environment:
+          TERM: xterm
     steps:
       - checkout
       - run:
@@ -44,16 +55,8 @@ workflows:
   deploy:
     jobs:
       - lock:
-          filters:
-            branches:
-              only:
-                - master
-                - /^cci-[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
+          <<: *master_and_cci_only
       - deploy:
           requires:
             - lock
-          filters:
-            branches:
-              only:
-                - master
-                - /^cci-[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
+          <<: *master_and_cci_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,8 @@ jobs:
             export APPLICATION_ENDPOINT=`./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH`
             popd
             ./test.sh
+      - store_test_results:
+          path: testcafe/testcafe_results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ master_and_cci_only: &master_and_cci_only
 
 orbs:
   browser-tools: circleci/browser-tools
-  
+
 jobs:
   lock:
     docker:
@@ -54,12 +54,13 @@ jobs:
             ./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH
   test:
     docker:
-      - image: circleci/node:jessie-browsers
+      - image: circleci/node:12
         environment:
           TERM: xterm
     steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
-      - run: ls -la
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,12 +59,12 @@ jobs:
       - run:
           name: Run TestCafe suite
           command: |
-            sudo npm install -g testcafe serverless testcafe-reporter-junit
+            sudo npm install -g testcafe serverless
             pushd services
             export APPLICATION_ENDPOINT=`./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH`
             popd
             ./test.sh
-      - store_test_results:
+      - store_artifacts:
           path: tests/testcafe/testcafe_results
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,3 @@ workflows:
           requires:
             - lock
           <<: *master_and_cci_only
-      - test:
-          requires:
-            - deploy
-          <<: *master_and_cci_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,13 @@ jobs:
           command: |
             cd services
             ./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH
+  test:
+    docker:
+      - image: circleci/node:12-browsers
+        environment:
+          TERM: xterm
+    steps:
+      - run: ls -la
 
 workflows:
   version: 2
@@ -59,4 +66,8 @@ workflows:
       - deploy:
           requires:
             - lock
+          <<: *master_and_cci_only
+      - test:
+          requires:
+            - deploy
           <<: *master_and_cci_only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,10 @@ jobs:
           name: Run TestCafe suite
           command: |
             sudo npm install -g testcafe serverless
-            cd services
+            pushd services
             export APPLICATION_ENDPOINT=`./output.sh ui CloudFrontEndpointUrl $STAGE_PREFIX$CIRCLE_BRANCH`
-            cd ../tests
-            testcafe "chrome:headless" testcafe/**/*.js
+            popd
+            ./test.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ master_and_cci_only: &master_and_cci_only
         - /^cci-[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
 
 orbs:
-  browser-tools: circleci/browser-tools
+  browser-tools: circleci/browser-tools@1.0.1
 
 jobs:
   lock:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 .infra
 node_modules
+testcafe_results

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-docker run --rm --network="data_net" --name test -e APPLICATION_ENDPOINT=http://react -v $(pwd)/testcafe:/tests testcafe/testcafe chromium /tests/**/*.js
+testcafe "chrome:headless" testcafe/**/*.js

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-testcafe "chrome:headless" testcafe/**/*.js --reporter json:testcafe/testcafe_results/results.json
+testcafe "chrome:headless" testcafe/**/*.js --reporter junit:testcafe/testcafe_results/results.json

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-testcafe "chrome:headless" testcafe/**/*.js --reporter junit:testcafe/testcafe_results/results.json
+testcafe "chrome:headless" testcafe/**/*.js --reporter json:testcafe/testcafe_results/results.json

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-testcafe "chrome:headless" testcafe/**/*.js
+testcafe "chrome:headless" testcafe/**/*.js --reporter json:testcafe/testcafe_results/results.json


### PR DESCRIPTION
This is a simple smoke test using testcafe.
I was hoping to use Cypress, but this is quick and easy.
Maybe have several frameworks ready to go in the repo, and the user can just choose.

Test results are archived as a build artifact.

Closes #14 