### PR TITLE
Build all branches except those beginning with skipci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,10 @@
 version: 2.0
 
-master_and_cci_only: &ignore_nocci
+ignore_branches_beginning_with_skipci: &ignore_branches_beginning_with_skipci
   filters:
     branches:
-      only:
-        - /^[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
       ignore:
-        - /^nocci-*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
+        - /^skipci.*/ # Ignore any branch that begin with skipci
 
 jobs:
   lock:
@@ -73,12 +71,12 @@ workflows:
   deploy:
     jobs:
       - lock:
-          <<: *ignore_nocci
+          <<: *ignore_branches_beginning_with_skipci
       - deploy:
           requires:
             - lock
-          <<: *ignore_nocci
+          <<: *ignore_branches_beginning_with_skipci
       - test:
           requires:
             - deploy
-          <<: *ignore_nocci
+          <<: *ignore_branches_beginning_with_skipci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.0
 
-
-master_and_cci_only: &master_and_cci_only
+master_and_cci_only: &ignore_nocci
   filters:
     branches:
       only:
-        - master
-        - /^cci-[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
+        - /^[a-zA-Z0-9-]*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
+      ignore:
+        - /^nocci-*$/ # Branch begins with cci- and only contains letters, numbers, and hyphens
 
 jobs:
   lock:
@@ -73,12 +73,12 @@ workflows:
   deploy:
     jobs:
       - lock:
-          <<: *master_and_cci_only
+          <<: *ignore_nocci
       - deploy:
           requires:
             - lock
-          <<: *master_and_cci_only
+          <<: *ignore_nocci
       - test:
           requires:
             - deploy
-          <<: *master_and_cci_only
+          <<: *ignore_nocci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.0
 
+
 master_and_cci_only: &master_and_cci_only
   filters:
     branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.0
 
-ignore_branches_beginning_with_skipci: &ignore_branches_beginning_with_skipci
+ignore_branches_that_begin_with_skipci: &ignore_branches_that_begin_with_skipci
   filters:
     branches:
       ignore:
@@ -71,12 +71,12 @@ workflows:
   deploy:
     jobs:
       - lock:
-          <<: *ignore_branches_beginning_with_skipci
+          <<: *ignore_branches_that_begin_with_skipci
       - deploy:
           requires:
             - lock
-          <<: *ignore_branches_beginning_with_skipci
+          <<: *ignore_branches_that_begin_with_skipci
       - test:
           requires:
             - deploy
-          <<: *ignore_branches_beginning_with_skipci
+          <<: *ignore_branches_that_begin_with_skipci


### PR DESCRIPTION
Closes #21 

This introduces a simple pattern for promoting code.  
All branches are built and deployed, except those that begin with skipci.
Deploying prod would be a merge from master to a branch called prod, which should be a protected branch.
Merge to prod and prod deploys.
The injection of prod specific environment variables is still supported with the 'set environment for deploy' block; that's unchanged.

What are the drawbacks here?  
- There's no decay; environments are built, but not automatically removed at end of life.  A developer or admin needs to run the destroy.sh script against built environments to take them down.

What's good?
- This is dirt simple.  All branches are built, unless you prefix it with skipci.
- All pull requests will show a status check from CCI.  Code can't get in without a green light.
- Affecting a staging/qa/prod deploy is a merge request.  All developers should be able to start a merge request with no trouble.  Completing a promotion (merging a pull request) is simple, and is easy enough to be delegating to a non technical resource or stakeholder if that's desired.
