### PR TITLE
Verify branch name before deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,30 @@ ignore_branches_that_begin_with_skipci: &ignore_branches_that_begin_with_skipci
         - /^skipci.*/ # Ignore any branch that begin with skipci
 
 jobs:
+  verify_branch:
+    docker:
+      - image: circleci/node:12
+        environment:
+          TERM: xterm
+    steps:
+      - run:
+          name: Check branch name is a legal serverless stage name
+          command: |
+            if [[ ! $CIRCLE_BRANCH =~ ^[a-zA-Z0-9-]*$ ]] || [[ ${#CIRCLE_BRANCH} -gt 128 ]]; then
+              echo '''
+                Bad branch name detected; cannot continue.
+
+                The Serverless Application Framework has a concept of stages that facilitate multiple deployments of the same service.
+                In this setup, the git branch name gets passed to Serverless to serve as the stage name.
+                Therefore, the branch name must be a valid stage name.
+
+                From Serverless:
+                  A service name should only contain alphanumeric (case sensitive) and hyphens. It should start with an alphabetic character and shouldnt exceed 128 characters.
+
+                For CircleCI support, please rename your branch so it is a valid Serverless stage name.
+              '''
+              exit 1
+            fi
   lock:
     docker:
       - image: circleci/node:12
@@ -70,7 +94,11 @@ workflows:
   version: 2
   deploy:
     jobs:
+      - verify_branch:
+          <<: *ignore_branches_that_begin_with_skipci
       - lock:
+          requires:
+            - verify_branch
           <<: *ignore_branches_that_begin_with_skipci
       - deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,13 @@ jobs:
 
                 The Serverless Application Framework has a concept of stages that facilitate multiple deployments of the same service.
                 In this setup, the git branch name gets passed to Serverless to serve as the stage name.
-                Therefore, the branch name must be a valid stage name.
+                The stage name (branch name in this case) is tacked onto the end of the service name by Serverless.
+                Therefore, the branch name must be a valid service name.
 
                 From Serverless:
                   A service name should only contain alphanumeric (case sensitive) and hyphens. It should start with an alphabetic character and shouldnt exceed 128 characters.
 
-                For CircleCI support, please rename your branch so it is a valid Serverless stage name.
+                For CircleCI support, please rename your branch so it is a valid Serverless service name.
                 ------------------------------------------------------------------------------------------------------------------------------
               """
               exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,8 @@ jobs:
       - run:
           name: Check branch name is a legal serverless stage name
           command: |
-            RED='\033[0;31m'
-            NC='\033[0m'
             if [[ ! $CIRCLE_BRANCH =~ ^[a-zA-Z0-9-]*$ ]] || [[ ${#CIRCLE_BRANCH} -gt 128 ]]; then
-              echo """${RED}
+              echo """
                 ------------------------------------------------------------------------------------------------------------------------------
                 ERROR:  Please read below
                 ------------------------------------------------------------------------------------------------------------------------------
@@ -34,7 +32,7 @@ jobs:
 
                 For CircleCI support, please rename your branch so it is a valid Serverless stage name.
                 ------------------------------------------------------------------------------------------------------------------------------
-              ${NC}"""
+              """
               exit 1
             fi
   lock:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,13 @@ jobs:
       - run:
           name: Check branch name is a legal serverless stage name
           command: |
+            RED='\033[0;31m'
+            NC='\033[0m'
             if [[ ! $CIRCLE_BRANCH =~ ^[a-zA-Z0-9-]*$ ]] || [[ ${#CIRCLE_BRANCH} -gt 128 ]]; then
-              echo '''
+              echo """${RED}
+                ------------------------------------------------------------------------------------------------------------------------------
+                ERROR:  Please read below
+                ------------------------------------------------------------------------------------------------------------------------------
                 Bad branch name detected; cannot continue.
 
                 The Serverless Application Framework has a concept of stages that facilitate multiple deployments of the same service.
@@ -28,7 +33,8 @@ jobs:
                   A service name should only contain alphanumeric (case sensitive) and hyphens. It should start with an alphabetic character and shouldnt exceed 128 characters.
 
                 For CircleCI support, please rename your branch so it is a valid Serverless stage name.
-              '''
+                ------------------------------------------------------------------------------------------------------------------------------
+              ${NC}"""
               exit 1
             fi
   lock:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
                 From Serverless:
                   A service name should only contain alphanumeric (case sensitive) and hyphens. It should start with an alphabetic character and shouldnt exceed 128 characters.
 
-                For CircleCI support, please rename your branch so it is a valid Serverless service name.
+                For CircleCI support, please push your code to a new branch with a name that meets Serverless' service name requirements.
+                So, make a new branch with a name that is made up of only letters, numbers, and hyphens... then delete this branch.
                 ------------------------------------------------------------------------------------------------------------------------------
               """
               exit 1


### PR DESCRIPTION
Since the introduction of 'build all branches', we are no longer filtering for bad branches at the circle ci level.
In other words, someone can push a branch called this_wont_work_with_serverless and it will run in CircleCI.. the underscores will break serverless when it gets to deployment.

This introduces some logic to verify the branch name will work with serverless.
Without this, serverless would fail and print an error message... and that's totally fine, but it might be confusing for unfamiliar developers.
The hope is that this fast failure and (i hope) nicely written error message with an explanation will click with a developer and guide him/her to the remedy.

