### PR TITLE
Adapt code to work with CMS Greenfield IAM restrictions

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -103,6 +103,7 @@ resources:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
+        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
         # ManagedPolicyArns:
         # - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         # Policies:
@@ -148,6 +149,7 @@ resources:
                 Service: 'lambda.amazonaws.com'
               Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
+        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
         # Policies:
         #   - PolicyName: 'Warmup'
         #     PolicyDocument:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -91,6 +91,12 @@ functions:
           authorizer: aws_iam
 
 resources:
+  Conditions:
+    CreatePermissionsBoundary:
+      Fn::Not:
+        - Fn::Equals:
+          - ""
+          - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
   Resources:
     LambdaApiRole: # Why isn't this with the function as an iamRoleStatements?  https://github.com/serverless/serverless/issues/6485
       Type: 'AWS::IAM::Role'
@@ -103,7 +109,11 @@ resources:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
-        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
+            - Ref: AWS::NoValue
         ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         Policies:
@@ -149,7 +159,11 @@ resources:
                 Service: 'lambda.amazonaws.com'
               Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
-        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
+            - Ref: AWS::NoValue
         Policies:
           - PolicyName: 'Warmup'
             PolicyDocument:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -148,21 +148,21 @@ resources:
                 Service: 'lambda.amazonaws.com'
               Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
-        Policies:
-          - PolicyName: 'Warmup'
-            PolicyDocument:
-              Version: '2012-10-17'
-              Statement:
-                - Effect: 'Allow'
-                  Action:
-                    - logs:CreateLogGroup
-                    - logs:CreateLogStream
-                    - logs:PutLogEvents
-                  Resource: 'arn:aws:logs:*:*:*'
-                - Effect: 'Allow'
-                  Action:
-                    - lambda:InvokeFunction
-                  Resource: '*'
+        # Policies:
+        #   - PolicyName: 'Warmup'
+        #     PolicyDocument:
+        #       Version: '2012-10-17'
+        #       Statement:
+        #         - Effect: 'Allow'
+        #           Action:
+        #             - logs:CreateLogGroup
+        #             - logs:CreateLogStream
+        #             - logs:PutLogEvents
+        #           Resource: 'arn:aws:logs:*:*:*'
+        #         - Effect: 'Allow'
+        #           Action:
+        #             - lambda:InvokeFunction
+        #           Resource: '*'
     GatewayResponseDefault4XX:
       Type: 'AWS::ApiGateway::GatewayResponse'
       Properties:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -39,23 +39,10 @@ provider:
     tableName: ${self:custom.tableName}
     atomicCounterTableName: ${self:custom.atomicCounterTableName}
 
-  iamRoleStatements:
-    - Effect: Allow
-      Action:
-        - dynamodb:DescribeTable
-        - dynamodb:Query
-        - dynamodb:Scan
-        - dynamodb:GetItem
-        - dynamodb:PutItem
-        - dynamodb:UpdateItem
-        - dynamodb:DeleteItem
-      Resource:
-        - ${self:custom.tableArn}
-        - ${self:custom.atomicCounterTableArn}
-
 functions:
   create:
     handler: create.main
+    role: LambdaApiRole
     events:
       - http:
           path: amendments
@@ -65,6 +52,7 @@ functions:
 
   get:
     handler: get.main
+    role: LambdaApiRole
     events:
       - http:
           path: amendments/{id}
@@ -74,6 +62,7 @@ functions:
 
   list:
     handler: list.main
+    role: LambdaApiRole
     events:
       - http:
           path: amendments
@@ -83,6 +72,7 @@ functions:
 
   update:
     handler: update.main
+    role: LambdaApiRole
     events:
       - http:
           path: amendments/{id}
@@ -92,6 +82,7 @@ functions:
 
   delete:
     handler: delete.main
+    role: LambdaApiRole
     events:
       - http:
           path: amendments/{id}
@@ -101,6 +92,51 @@ functions:
 
 resources:
   Resources:
+    LambdaApiRole: # Why isn't this with the function as an iamRoleStatements?  https://github.com/serverless/serverless/issues/6485
+      Type: 'AWS::IAM::Role'
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service: 'lambda.amazonaws.com'
+            Action: 'sts:AssumeRole'
+        Path: '/delegatedadmin/developer/'
+        ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        Policies:
+          - PolicyName: 'LambdaApiRolePolicy'
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+              - Effect: 'Allow'
+                Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+                Resource: 'arn:aws:logs:*:*:*'
+              - Effect: 'Allow'
+                Action:
+                - dynamodb:DescribeTable
+                - dynamodb:Query
+                - dynamodb:Scan
+                - dynamodb:GetItem
+                - dynamodb:PutItem
+                - dynamodb:UpdateItem
+                - dynamodb:DeleteItem
+                Resource:
+                - ${self:custom.tableArn}
+                - ${self:custom.atomicCounterTableArn}
+              # - Effect: 'Allow'
+              #   Action:
+              #   - logs:CreateLogStream
+              #   - logs:CreateLogGroup
+              #   - Resource:
+              #     - Fn::Join:
+              #       - "/"
+              #       -
+              #         - Fn::Join: [":", ["arn:aws:execute-api", {"Ref": "AWS::Region"}, {"Ref":"AWS::AccountId"}, {"Ref": "ApiGatewayRestApi"}]]
     LambdaWarmupRole:
       Type: 'AWS::IAM::Role'
       Properties:
@@ -111,7 +147,7 @@ resources:
               Principal:
                 Service: 'lambda.amazonaws.com'
               Action: 'sts:AssumeRole'
-        Path: '/'
+        Path: '/delegatedadmin/developer/'
         Policies:
           - PolicyName: 'Warmup'
             PolicyDocument:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -15,6 +15,7 @@ custom:
   tableArn: ${cf:database-${self:custom.stage}.AmendmentsTableArn}
   atomicCounterTableName: ${cf:database-${self:custom.stage}.AmendmentsAtomicCounterTableName}
   atomicCounterTableArn: ${cf:database-${self:custom.stage}.AmendmentsAtomicCounterTableArn}
+  iamPath: ${env:IAM_PATH, "/"}
   warmupEnabled:
     production: true
     development: false
@@ -108,7 +109,7 @@ resources:
             Principal:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
-        Path: '/delegatedadmin/developer/'
+        Path: ${self:custom.iamPath}
         PermissionsBoundary:
           Fn::If:
             - CreatePermissionsBoundary
@@ -158,7 +159,7 @@ resources:
               Principal:
                 Service: 'lambda.amazonaws.com'
               Action: 'sts:AssumeRole'
-        Path: '/delegatedadmin/developer/'
+        Path: ${self:custom.iamPath}
         PermissionsBoundary:
           Fn::If:
             - CreatePermissionsBoundary

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -113,27 +113,27 @@ resources:
               Statement:
               - Effect: 'Allow'
                 Action:
-                - logs:CreateLogGroup
-                - logs:CreateLogStream
-                - logs:PutLogEvents
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
                 Resource: 'arn:aws:logs:*:*:*'
               - Effect: 'Allow'
                 Action:
-                - dynamodb:DescribeTable
-                - dynamodb:Query
-                - dynamodb:Scan
-                - dynamodb:GetItem
-                - dynamodb:PutItem
-                - dynamodb:UpdateItem
-                - dynamodb:DeleteItem
+                  - dynamodb:DescribeTable
+                  - dynamodb:Query
+                  - dynamodb:Scan
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                  - dynamodb:UpdateItem
+                  - dynamodb:DeleteItem
                 Resource:
-                - ${self:custom.tableArn}
-                - ${self:custom.atomicCounterTableArn}
+                  - ${self:custom.tableArn}
+                  - ${self:custom.atomicCounterTableArn}
               - Effect: 'Allow'
                 Action:
-                - logs:CreateLogStream
-                - logs:CreateLogGroup
-                - Resource:
+                  - logs:CreateLogStream
+                  - logs:CreateLogGroup
+                Resource:
                   - Fn::Join:
                     - "/"
                     -

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -105,30 +105,30 @@ resources:
         Path: '/delegatedadmin/developer/'
         ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-        Policies:
-          - PolicyName: 'LambdaApiRolePolicy'
-            PolicyDocument:
-              Version: '2012-10-17'
-              Statement:
-              - Effect: 'Allow'
-                Action:
-                - logs:CreateLogGroup
-                - logs:CreateLogStream
-                - logs:PutLogEvents
-                Resource: 'arn:aws:logs:*:*:*'
-              - Effect: 'Allow'
-                Action:
-                - dynamodb:DescribeTable
-                - dynamodb:Query
-                - dynamodb:Scan
-                - dynamodb:GetItem
-                - dynamodb:PutItem
-                - dynamodb:UpdateItem
-                - dynamodb:DeleteItem
-                Resource:
-                - ${self:custom.tableArn}
-                - ${self:custom.atomicCounterTableArn}
-              # - Effect: 'Allow'
+        # Policies:
+        #   - PolicyName: 'LambdaApiRolePolicy'
+        #     PolicyDocument:
+        #       Version: '2012-10-17'
+        #       Statement:
+        #       - Effect: 'Allow'
+        #         Action:
+        #         - logs:CreateLogGroup
+        #         - logs:CreateLogStream
+        #         - logs:PutLogEvents
+        #         Resource: 'arn:aws:logs:*:*:*'
+        #       - Effect: 'Allow'
+        #         Action:
+        #         - dynamodb:DescribeTable
+        #         - dynamodb:Query
+        #         - dynamodb:Scan
+        #         - dynamodb:GetItem
+        #         - dynamodb:PutItem
+        #         - dynamodb:UpdateItem
+        #         - dynamodb:DeleteItem
+        #         Resource:
+        #         - ${self:custom.tableArn}
+        #         - ${self:custom.atomicCounterTableArn}
+        #       # - Effect: 'Allow'
               #   Action:
               #   - logs:CreateLogStream
               #   - logs:CreateLogGroup

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -104,40 +104,40 @@ resources:
             Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
         PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
-        # ManagedPolicyArns:
-        # - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-        # Policies:
-        #   - PolicyName: 'LambdaApiRolePolicy'
-        #     PolicyDocument:
-        #       Version: '2012-10-17'
-        #       Statement:
-        #       - Effect: 'Allow'
-        #         Action:
-        #         - logs:CreateLogGroup
-        #         - logs:CreateLogStream
-        #         - logs:PutLogEvents
-        #         Resource: 'arn:aws:logs:*:*:*'
-        #       - Effect: 'Allow'
-        #         Action:
-        #         - dynamodb:DescribeTable
-        #         - dynamodb:Query
-        #         - dynamodb:Scan
-        #         - dynamodb:GetItem
-        #         - dynamodb:PutItem
-        #         - dynamodb:UpdateItem
-        #         - dynamodb:DeleteItem
-        #         Resource:
-        #         - ${self:custom.tableArn}
-        #         - ${self:custom.atomicCounterTableArn}
-        #       # - Effect: 'Allow'
-              #   Action:
-              #   - logs:CreateLogStream
-              #   - logs:CreateLogGroup
-              #   - Resource:
-              #     - Fn::Join:
-              #       - "/"
-              #       -
-              #         - Fn::Join: [":", ["arn:aws:execute-api", {"Ref": "AWS::Region"}, {"Ref":"AWS::AccountId"}, {"Ref": "ApiGatewayRestApi"}]]
+        ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        Policies:
+          - PolicyName: 'LambdaApiRolePolicy'
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+              - Effect: 'Allow'
+                Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+                Resource: 'arn:aws:logs:*:*:*'
+              - Effect: 'Allow'
+                Action:
+                - dynamodb:DescribeTable
+                - dynamodb:Query
+                - dynamodb:Scan
+                - dynamodb:GetItem
+                - dynamodb:PutItem
+                - dynamodb:UpdateItem
+                - dynamodb:DeleteItem
+                Resource:
+                - ${self:custom.tableArn}
+                - ${self:custom.atomicCounterTableArn}
+              # - Effect: 'Allow'
+                Action:
+                - logs:CreateLogStream
+                - logs:CreateLogGroup
+                - Resource:
+                  - Fn::Join:
+                    - "/"
+                    -
+                      - Fn::Join: [":", ["arn:aws:execute-api", {"Ref": "AWS::Region"}, {"Ref":"AWS::AccountId"}, {"Ref": "ApiGatewayRestApi"}]]
     LambdaWarmupRole:
       Type: 'AWS::IAM::Role'
       Properties:
@@ -150,21 +150,21 @@ resources:
               Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
         PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
-        # Policies:
-        #   - PolicyName: 'Warmup'
-        #     PolicyDocument:
-        #       Version: '2012-10-17'
-        #       Statement:
-        #         - Effect: 'Allow'
-        #           Action:
-        #             - logs:CreateLogGroup
-        #             - logs:CreateLogStream
-        #             - logs:PutLogEvents
-        #           Resource: 'arn:aws:logs:*:*:*'
-        #         - Effect: 'Allow'
-        #           Action:
-        #             - lambda:InvokeFunction
-        #           Resource: '*'
+        Policies:
+          - PolicyName: 'Warmup'
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: 'Allow'
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource: 'arn:aws:logs:*:*:*'
+                - Effect: 'Allow'
+                  Action:
+                    - lambda:InvokeFunction
+                  Resource: '*'
     GatewayResponseDefault4XX:
       Type: 'AWS::ApiGateway::GatewayResponse'
       Properties:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -103,8 +103,8 @@ resources:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
-        ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        # ManagedPolicyArns:
+        # - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         # Policies:
         #   - PolicyName: 'LambdaApiRolePolicy'
         #     PolicyDocument:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -129,7 +129,7 @@ resources:
                 Resource:
                 - ${self:custom.tableArn}
                 - ${self:custom.atomicCounterTableArn}
-              # - Effect: 'Allow'
+              - Effect: 'Allow'
                 Action:
                 - logs:CreateLogStream
                 - logs:CreateLogGroup

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -19,6 +19,17 @@ provider:
 
 resources:
   Resources:
+    DelegatedRoleTest:
+      Type: 'AWS::IAM::Role'
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: 'Allow'
+              Principal:
+                Service: 'lambda.amazonaws.com'
+              Action: 'sts:AssumeRole'
+        Path: '/delegatedadmin/developer/'
     AmendmentsTable:
       Type: AWS::DynamoDB::Table
       Properties:

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -22,6 +22,7 @@ resources:
     DelegatedRoleTest:
       Type: 'AWS::IAM::Role'
       Properties:
+        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -19,18 +19,6 @@ provider:
 
 resources:
   Resources:
-    DelegatedRoleTest:
-      Type: 'AWS::IAM::Role'
-      Properties:
-        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: 'Allow'
-              Principal:
-                Service: 'lambda.amazonaws.com'
-              Action: 'sts:AssumeRole'
-        Path: '/delegatedadmin/developer/'
     AmendmentsTable:
       Type: AWS::DynamoDB::Table
       Properties:

--- a/services/elasticsearch-auth/serverless.yml
+++ b/services/elasticsearch-auth/serverless.yml
@@ -6,6 +6,7 @@ package:
 
 custom:
   stage: ${opt:stage, self:provider.stage}
+  iamPath: ${env:IAM_PATH, "/"}
 
 provider:
   name: aws
@@ -86,7 +87,7 @@ resources:
     CognitoAuthRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: '/delegatedadmin/developer/'
+        Path: ${self:custom.iamPath}
         PermissionsBoundary:
           Fn::If:
             - CreatePermissionsBoundary

--- a/services/elasticsearch-auth/serverless.yml
+++ b/services/elasticsearch-auth/serverless.yml
@@ -20,7 +20,11 @@ resources:
         - Fn::Equals:
           - ""
           - ${env:SES_SOURCE_EMAIL_ARN, ""}
-
+    CreatePermissionsBoundary:
+      Fn::Not:
+        - Fn::Equals:
+          - ""
+          - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
   Resources:
     CognitoUserPool:
       Type: AWS::Cognito::UserPool
@@ -83,7 +87,11 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         Path: '/delegatedadmin/developer/'
-        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
+            - Ref: AWS::NoValue
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/services/elasticsearch-auth/serverless.yml
+++ b/services/elasticsearch-auth/serverless.yml
@@ -40,7 +40,12 @@ resources:
     CognitoUserPoolDomain:
       Type: AWS::Cognito::UserPoolDomain
       Properties:
-        Domain: ${self:custom.stage}-elasticsearch-user-pool
+        Domain:
+          Fn::Join:
+            - "-"
+            -
+              - !Ref "AWS::AccountId"
+              - ${self:custom.stage}-elasticsearch-user-pool
         UserPoolId:
           Ref: CognitoUserPool
 
@@ -77,7 +82,8 @@ resources:
     CognitoAuthRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: /
+        Path: '/delegatedadmin/developer/'
+        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/services/elasticsearch/serverless.yml
+++ b/services/elasticsearch/serverless.yml
@@ -9,6 +9,7 @@ custom:
   cognito_identity_pool_id: ${cf:elasticsearch-auth-${self:custom.stage}.IdentityPoolId}
   cognito_identity_pool_authenticated_role_arn: ${cf:elasticsearch-auth-${self:custom.stage}.IdentityPoolAuthenticatedRoleArn}
   cognito_user_pool_id: ${cf:elasticsearch-auth-${self:custom.stage}.UserPoolId}
+  iamPath: ${env:IAM_PATH, "/"}
 
 provider:
   name: aws
@@ -78,7 +79,7 @@ resources:
     EsCognitoRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: '/delegatedadmin/developer/'
+        Path: ${self:custom.iamPath}
         PermissionsBoundary:
           Fn::If:
             - CreatePermissionsBoundary

--- a/services/elasticsearch/serverless.yml
+++ b/services/elasticsearch/serverless.yml
@@ -73,7 +73,8 @@ resources:
     EsCognitoRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: /
+        Path: '/delegatedadmin/developer/'
+        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/services/elasticsearch/serverless.yml
+++ b/services/elasticsearch/serverless.yml
@@ -22,6 +22,11 @@ resources:
       Fn::Equals:
         - ${env:INFRASTRUCTURE_TYPE, ""}
         - "production"
+    CreatePermissionsBoundary:
+      Fn::Not:
+        - Fn::Equals:
+          - ""
+          - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
   Resources:
     ElasticSearchInstance:
       Type: AWS::Elasticsearch::Domain
@@ -74,7 +79,11 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         Path: '/delegatedadmin/developer/'
-        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
+            - Ref: AWS::NoValue
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/services/stream-functions/serverless.yml
+++ b/services/stream-functions/serverless.yml
@@ -16,6 +16,7 @@ custom:
   elasticSearchDomainArn: ${cf:elasticsearch-${self:custom.stage}.ElasticSearchDomainArn}
   emailSource: ${opt:emailSource, env:SES_SOURCE_EMAIL_ADDRESS, "admin@example.com"}
   reviewerEmail: ${opt:reviewTeamEmail, env:SES_REVIEW_TEAM_EMAIL_ADDRESS, "reviewteam@example.com"}
+  iamPath: ${env:IAM_PATH, "/"}
 
 provider:
   name: aws
@@ -79,7 +80,7 @@ resources:
             Principal:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
-        Path: '/delegatedadmin/developer/'
+        Path: ${self:custom.iamPath}
         PermissionsBoundary:
           Fn::If:
             - CreatePermissionsBoundary
@@ -117,7 +118,7 @@ resources:
             Principal:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
-        Path: '/delegatedadmin/developer/'
+        Path: ${self:custom.iamPath}
         PermissionsBoundary:
           Fn::If:
             - CreatePermissionsBoundary

--- a/services/stream-functions/serverless.yml
+++ b/services/stream-functions/serverless.yml
@@ -62,6 +62,12 @@ functions:
     maximumRetryAttempts: 2
 
 resources:
+  Conditions:
+    CreatePermissionsBoundary:
+      Fn::Not:
+        - Fn::Equals:
+          - ""
+          - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
   Resources:
     LambdaElasticSearchIndexerRole: # Why isn't this with the function as an iamRoleStatements?  https://github.com/serverless/serverless/issues/6485
       Type: 'AWS::IAM::Role'
@@ -74,7 +80,11 @@ resources:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
-        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
+            - Ref: AWS::NoValue
         Policies:
           - PolicyName: 'LambdaRolePolicy'
             PolicyDocument:
@@ -108,7 +118,11 @@ resources:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
         Path: '/delegatedadmin/developer/'
-        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
+            - Ref: AWS::NoValue
         Policies:
           - PolicyName: 'LambdaRolePolicy'
             PolicyDocument:

--- a/services/stream-functions/serverless.yml
+++ b/services/stream-functions/serverless.yml
@@ -73,7 +73,8 @@ resources:
             Principal:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
-        Path: '/'
+        Path: '/delegatedadmin/developer/'
+        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
         Policies:
           - PolicyName: 'LambdaRolePolicy'
             PolicyDocument:
@@ -106,7 +107,8 @@ resources:
             Principal:
               Service: 'lambda.amazonaws.com'
             Action: 'sts:AssumeRole'
-        Path: '/'
+        Path: '/delegatedadmin/developer/'
+        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
         Policies:
           - PolicyName: 'LambdaRolePolicy'
             PolicyDocument:

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -26,7 +26,11 @@ resources:
         - Fn::Equals:
           - ""
           - ${env:SES_SOURCE_EMAIL_ARN, ""}
-
+    CreatePermissionsBoundary:
+      Fn::Not:
+        - Fn::Equals:
+          - ""
+          - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
   Resources:
     CognitoUserPool:
       Type: AWS::Cognito::UserPool
@@ -89,7 +93,11 @@ resources:
       Type: AWS::IAM::Role
       Properties:
         Path: '/delegatedadmin/developer/'
-        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - ${env:IAM_PERMISSIONS_BOUNDARY_ARN, ""}
+            - Ref: AWS::NoValue
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -11,6 +11,7 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   attachments_bucket_arn: ${cf:uploads-${self:custom.stage}.AttachmentsBucketArn}
   api_gateway_rest_api_name: ${cf:app-api-${self:custom.stage}.ApiGatewayRestApiName}
+  iamPath: ${env:IAM_PATH, "/"}
 
 # The `provider` block defines where your service will be deployed
 provider:
@@ -92,7 +93,7 @@ resources:
     CognitoAuthRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: '/delegatedadmin/developer/'
+        Path: ${self:custom.iamPath}
         PermissionsBoundary:
           Fn::If:
             - CreatePermissionsBoundary

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -88,7 +88,8 @@ resources:
     CognitoAuthRole:
       Type: AWS::IAM::Role
       Properties:
-        Path: /
+        Path: '/delegatedadmin/developer/'
+        PermissionsBoundary: arn:aws:iam::121499393294:policy/cms-cloud-admin/developer-boundary-policy
         AssumeRolePolicyDocument:
           Version: '2012-10-17'
           Statement:


### PR DESCRIPTION
Closes #9 

Greenfield accounts have users restricted to IAM operations inside a given path.  
Roles must also be created with a certain permissions boundary specified.
These changes allow for IAM_PERMISSIONS_BOUNDARY_ARN and IAM_PATH to be specified as environment variables... these settings will globally create all IAM objects at that path and with that boundary

The permissions boundary ARN should be converted to just the permissions boundary policy name; the arn can be predicted since it's form is known.  That can be handled in a future issue.  And on that note, the SES_SOURCE_EMAIL_ARN should also be generated from the source email and the arn's known form.