### PR TITLE
Standardize service structure

### DIFF
--- a/.circleci/package.json
+++ b/.circleci/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/CMSgov/macpro-quickstart-serverless.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/CMSgov/macpro-quickstart-serverless/issues"
   },

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,15 +17,25 @@ services=(
   'ui-src'
 )
 
+install_deps() {
+  if [ "$CI" == "true" ]; then # If we're in a CI system
+    if [ ! -d "node_modules" ]; then # If we don't have any node_modules (CircleCI cache miss scenario), run npm ci.  Otherwise, we're all set, do nothing.
+      npm ci
+    fi
+  else # We're not in a CI system, let's npm install
+    npm install
+  fi
+}
+
 deploy() {
   service=$1
   pushd services/$service
-  if [ -f "package-lock.json" ] && [ ! -d "node_modules" ]; then
-    npm ci
-  fi
+  install_deps
   serverless deploy  --stage $stage
   popd
 }
+
+install_deps
 
 for i in "${services[@]}"
 do

--- a/package.json
+++ b/package.json
@@ -1,15 +1,10 @@
 {
   "name": "macpro-quickstart-serverless",
   "version": "1.0.0",
-  "description": "A serverless form submission application built and deployed to AWS with the Serverless Application Framework.",
+  "description": "",
   "main": "index.js",
   "directories": {
     "test": "tests"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "serverless": "^1.82.0",
-    "testcafe": "^1.8.5"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -19,7 +14,7 @@
     "url": "git+https://github.com/CMSgov/macpro-quickstart-serverless.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/CMSgov/macpro-quickstart-serverless/issues"
   },

--- a/services/app-api/package-lock.json
+++ b/services/app-api/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "stream-functions",
-  "version": "1.1.3",
+  "name": "app-api",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "stream-functions",
-  "version": "1.1.3",
-  "description": "A Node.js starter for the Serverless Framework with async/await and unit test support",
+  "name": "app-api",
+  "description": "",
+  "version": "1.0.0",
   "main": "handler.js",
   "scripts": {
     "test": "serverless-bundle test"
   },
   "author": "",
-  "license": "MIT",
+  "license": "CC0-1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/AnomalyInnovations/serverless-nodejs-starter.git"

--- a/services/database/package-lock.json
+++ b/services/database/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "macpro-quickstart-serverless",
+  "name": "database",
   "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/services/database/package.json
+++ b/services/database/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "database",
+  "description": "",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "CC0-1.0"
+}

--- a/services/elasticsearch-auth/package-lock.json
+++ b/services/elasticsearch-auth/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "macpro-quickstart-serverless",
+  "name": "elasticsearch-auth",
   "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/services/elasticsearch-auth/package.json
+++ b/services/elasticsearch-auth/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "elasticsearch-auth",
+  "description": "",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "CC0-1.0"
+}

--- a/services/elasticsearch-config/package-lock.json
+++ b/services/elasticsearch-config/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticsearch-config",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/services/elasticsearch-config/package.json
+++ b/services/elasticsearch-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elasticsearch-config",
   "description": "",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "dependencies": {
     "dynamodb-stream-elasticsearch": "^2.11.1"
   },

--- a/services/elasticsearch/package-lock.json
+++ b/services/elasticsearch/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "macpro-quickstart-serverless",
+  "name": "elasticsearch",
   "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/services/elasticsearch/package.json
+++ b/services/elasticsearch/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "elasticsearch",
+  "description": "",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "CC0-1.0"
+}

--- a/services/stream-functions/package-lock.json
+++ b/services/stream-functions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stream-functions",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/services/stream-functions/package.json
+++ b/services/stream-functions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stream-functions",
   "description": "",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "dependencies": {
     "dynamo-to-elasticsearch-nodejs": "^1.0.5",
     "dynamodb-stream-elasticsearch": "^2.11.1"

--- a/services/ui-auth/package-lock.json
+++ b/services/ui-auth/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "macpro-quickstart-serverless",
+  "name": "ui-auth",
   "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/services/ui-auth/package.json
+++ b/services/ui-auth/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ui-auth",
+  "description": "",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "CC0-1.0"
+}

--- a/services/ui-src/package-lock.json
+++ b/services/ui-src/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "aps-app",
-  "version": "0.1.0",
+  "name": "ui-src",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "aps-app",
-  "version": "0.1.0",
-  "private": true,
+  "name": "ui-src",
+  "description": "",
+  "version": "1.0.0",
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",

--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "macpro-quickstart-serverless",
+  "name": "ui",
   "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ui",
+  "description": "",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "CC0-1.0"
+}

--- a/services/uploads/package-lock.json
+++ b/services/uploads/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "macpro-quickstart-serverless",
+  "name": "uploads",
   "version": "1.0.0",
   "lockfileVersion": 1
 }

--- a/services/uploads/package.json
+++ b/services/uploads/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "uploads",
+  "description": "",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "CC0-1.0"
+}


### PR DESCRIPTION
This standardized the monorepo's services' structure.  Each has a package.json and lock, whether or not it has node dependencies.  There's no time hit in doing this, and it simplifies install logic.

Logic in deploy.sh was added to ensure that if a developer runs deploy.sh, dependencies are installed via npm install.
If a CI system runs deploy.sh, the existence of node_modules in a given directory is taken as an indication of a cache hit/miss.  Dependencies are therefore installed via npm ci if no node_modules is present.