### PR TITLE
Add a script to set any of a list of branch specific env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,15 +109,8 @@ jobs:
           keys:
             - npm-cache3-{{ arch }}-{{ .Branch }}-{{ checksum "combined-package-lock.txt" }}
       - run:
-          name: set environment for deploy
-          command: |
-            # Environment variable names cannot contain hyphens
-            # So here we take the branch name, swap hyphens for underscores, and set variables if they exist.
-            echo "export ROUTE_53_HOSTED_ZONE_ID=\$${CIRCLE_BRANCH//-/_}_ROUTE_53_HOSTED_ZONE_ID" >> $BASH_ENV
-            echo "export ROUTE_53_DOMAIN_NAME=\$${CIRCLE_BRANCH//-/_}_ROUTE_53_DOMAIN_NAME" >> $BASH_ENV
-            echo "export CLOUDFRONT_CERTIFICATE_ARN=\$${CIRCLE_BRANCH//-/_}_CLOUDFRONT_CERTIFICATE_ARN" >> $BASH_ENV
-            echo "export CLOUDFRONT_DOMAIN_NAME=\$${CIRCLE_BRANCH//-/_}_CLOUDFRONT_DOMAIN_NAME" >> $BASH_ENV
-            echo "export INFRASTRUCTURE_TYPE=\$${CIRCLE_BRANCH//-/_}_INFRASTRUCTURE_TYPE" >> $BASH_ENV
+          name: set branch specific environment variables
+          command: ./.circleci/set_vars.sh
       - run: ./.circleci/ctkey.sh
       - run:
           name: deploy

--- a/.circleci/set_vars.sh
+++ b/.circleci/set_vars.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+branch_specific_vars=(
+  'INFRASTRUCTURE_TYPE'
+  'ROUTE_53_HOSTED_ZONE_ID'
+  'ROUTE_53_DOMAIN_NAME'
+  'CLOUDFRONT_CERTIFICATE_ARN'
+  'CLOUDFRONT_DOMAIN_NAME'
+  'SES_SOURCE_EMAIL_ADDRESS'
+  'SES_REVIEW_TEAM_EMAIL_ADDRESS'
+)
+
+override_var_if_set() {
+  varname=${1}
+  # Environment variable names cannot contain hyphens
+  # So here we take the branch name, swap hyphens for underscores, and set variables if they exist.
+  branch=${CIRCLE_BRANCH//-/_}
+  branch_specific_varname=${branch}_${1}
+  if [ ! -z "${!branch_specific_varname}" ]; then
+    echo """
+Environment variable ${branch_specific_varname} has a value.
+Setting the value of ${varname} to ${branch_specific_varname}'s value'
+    """
+    echo "export ${varname}=\$${branch_specific_varname}" >> $BASH_ENV
+  fi
+  # echo $var
+}
+
+for i in "${branch_specific_vars[@]}"
+do
+	override_var_if_set $i
+done


### PR DESCRIPTION
Closes #54 

set_vars.sh has been added to the .circleci folder.
It contains a list of environment variables that we may want to override on a per branch basis.
For example:
  Setting master_SES_SOURCE_EMAIL_ADDRESS=actualprod@cms.gov as a circleci project environment variable will apply that value of SES_SOURCE_EMAIL_ADDRESS on the master branch only.  In this way, you may specify specific values for specific branches.

If you want to set a value for a certain branch, and default all other branches to another value, the recommended pattern is:
- set SES_SOURCE_EMAIL_ADDRESS=adefaultemail@cms.gov in CircleCI.  This will apply to all branches.
- set master_SES_SOURCE_EMAIL_ADDRESS=myrealprodemail@cms.gov in CircleCI.  This will be set on the master branch only, for example, and override that default value.
- If you had a certain value for val, continue the pattern... simple set val_SES_SOURCE_EMAIL_ADDRESS=myvalemail@cms.gov