### PR TITLE
Deploy to different AWS Accounts - add support for non-cloudtamer accts

### DIFF
--- a/.circleci/set_vars.sh
+++ b/.circleci/set_vars.sh
@@ -13,6 +13,8 @@ branch_specific_vars=(
   'CTKEY_PASSWORD'
   'CTKEY_ACCOUNT_ID'
   'CTKEY_IAM_ROLE'
+  'AWS_ACCESS_KEY_ID'
+  'AWS_SECRET_ACCESS_KEY'
 )
 
 override_var_if_set() {


### PR DESCRIPTION
Closes #56 
I realized I closed this issue without addressing non-cloudtamer accounts, which would use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY instead of CTKEY variables.