### PR TITLE
Fix warmup bug and make warmup deployments idempotent

### DIFF
--- a/services/app-api/package-lock.json
+++ b/services/app-api/package-lock.json
@@ -2193,15 +2193,6 @@
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -3361,39 +3352,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "copy-webpack-plugin": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
-      "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
-      "dev": true,
-      "requires": {
-        "cacache": "^12.0.3",
-        "find-cache-dir": "^2.1.0",
-        "glob-parent": "^3.1.0",
-        "globby": "^7.1.1",
-        "is-glob": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "minimatch": "^3.0.4",
-        "normalize-path": "^3.0.0",
-        "p-limit": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^4.0.0",
-        "webpack-log": "^2.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
-      }
-    },
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
@@ -3795,15 +3753,6 @@
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
-      }
-    },
-    "dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-      "dev": true,
-      "requires": {
-        "path-type": "^3.0.0"
       }
     },
     "doctrine": {
@@ -4943,34 +4892,6 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
-    "globby": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
-      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-          "dev": true
-        }
-      }
-    },
     "globule": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
@@ -5266,12 +5187,6 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-      "dev": true
-    },
-    "ignore": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "ignore-loader": {
@@ -8405,23 +8320,6 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
-    },
     "pbkdf2": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -9722,6 +9620,98 @@
         "tsconfig-paths-webpack-plugin": "^3.2.0",
         "typescript": "^3.8.3",
         "webpack": "^4.35.3"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "dev": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "copy-webpack-plugin": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+          "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
+          "dev": true,
+          "requires": {
+            "cacache": "^12.0.3",
+            "find-cache-dir": "^2.1.0",
+            "glob-parent": "^3.1.0",
+            "globby": "^7.1.1",
+            "is-glob": "^4.0.1",
+            "loader-utils": "^1.2.3",
+            "minimatch": "^3.0.4",
+            "normalize-path": "^3.0.0",
+            "p-limit": "^2.2.1",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^4.0.0",
+            "webpack-log": "^2.0.0"
+          }
+        },
+        "dir-glob": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+          "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+          "dev": true,
+          "requires": {
+            "path-type": "^3.0.0"
+          }
+        },
+        "globby": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
       }
     },
     "serverless-dotenv-plugin": {
@@ -9786,6 +9776,12 @@
           }
         }
       }
+    },
+    "serverless-plugin-scripts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-scripts/-/serverless-plugin-scripts-1.0.2.tgz",
+      "integrity": "sha1-IYCMPP0KGoTkjAZgsPbzcLVmVIY=",
+      "dev": true
     },
     "serverless-plugin-warmup": {
       "version": "4.9.0",

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -16,6 +16,7 @@
     "aws-sdk": "^2.655.0",
     "serverless-bundle": "^3.0.0",
     "serverless-dotenv-plugin": "^3.0.0",
+    "serverless-plugin-scripts": "^1.0.2",
     "serverless-plugin-warmup": "^4.9.0"
   },
   "dependencies": {

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -35,8 +35,10 @@ custom:
         # Remove the timestamp line from the warmup handler so a new function is uploaded
         #   only if a configuration has truly changed.
         set -e
-        cd node_modules/serverless-bundle/src/_warmup
-        sed '/Generated/d' index.js > index.js.sub && mv -f index.js.sub index.js
+        if [ -d "node_modules/serverless-bundle/src/_warmup" ]; then
+          cd node_modules/serverless-bundle/src/_warmup
+          sed '/Generated/d' index.js > index.js.sub && mv -f index.js.sub index.js
+        fi
 
 provider:
   name: aws

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -7,7 +7,7 @@ plugins:
   - serverless-bundle
   - serverless-dotenv-plugin
   - serverless-plugin-warmup
-
+  - serverless-plugin-scripts
 custom:
   stage: ${opt:stage, self:provider.stage}
   tableName: ${cf:database-${self:custom.stage}.AmendmentsTableName}
@@ -27,7 +27,16 @@ custom:
     timeout: 20
     prewarm: true
     concurrency: 5
-
+    folderName: node_modules/serverless-bundle/src/_warmup
+    cleanFolder: false
+  scripts:
+    hooks:
+      package:setupProviderConfiguration: |
+        # Remove the timestamp line from the warmup handler so a new function is uploaded
+        #   only if a configuration has truly changed.
+        set -e
+        cd node_modules/serverless-bundle/src/_warmup
+        sed '/Generated/d' index.js > index.js.sub && mv -f index.js.sub index.js
 
 provider:
   name: aws


### PR DESCRIPTION
Closes #67 
2 things here:
- #67 bug fix... The generated warmup handler was not in the place the copy-webpack expected it to be.  This can be resolved a few ways, but the easiest was decided to be by telling the warmup plugin to generate the handler at the expected path.
- The third line in the handler the warmup plugin generates is essentially a timestamp.  Therefore, redeploying the app-api service with no real changes would still force a stack update, since the warmup function's source code changed slightly (timestamp).  This was solved by running a hook before packaging is finalized... the hook finds the timestamp line and removes it with sed.

This should drop the no-op build time on master / INFRASTUCTURE_TYPE=prod branches by about 30 seconds