### PR TITLE
Reduce the elasticsearch instance type for production envs

### DIFF
--- a/services/elasticsearch/serverless.yml
+++ b/services/elasticsearch/serverless.yml
@@ -39,8 +39,12 @@ resources:
         ElasticsearchClusterConfig:
           Fn::If:
             - BuildProdInfrastructure
-            - InstanceType: m5.large.elasticsearch
-              InstanceCount: 3
+            # - InstanceType: m5.large.elasticsearch
+            #   InstanceCount: 3
+            # To save on infra costs for the quickstart project, we will deploy a cheaper elasticsearch cluster for production
+            # To deploy a more powerful cluster for 'production' envs, uncomment the lines above and comment the lines above
+            - InstanceType: t2.small.elasticsearch
+              InstanceCount: 1
               DedicatedMasterEnabled: false
             - InstanceType: t2.small.elasticsearch
               InstanceCount: 1


### PR DESCRIPTION
There's logic in the quickstart... when INFRASTRUCTURE_TYPE=production, there's a few places where we build bigger/more highly provisioned infra.  This is to demonstrate a way to conditionally build different infra for different requirements.

Well, elasticsearch isn't exactly cheap.  So I want to reel in the size of the INFRASTRUCTURE_TYPE=production ES cluster.

I'm leaving the logic and switch in place, it's just the same value for both cases.  So someone should be able to easily modify this to build the sizes they want.  