### PR TITLE
Reduce ES cost - set encryption to false for smaller instance usage

### DIFF
--- a/services/elasticsearch/serverless.yml
+++ b/services/elasticsearch/serverless.yml
@@ -52,12 +52,14 @@ resources:
         EncryptionAtRestOptions:
           Fn::If:
             - BuildProdInfrastructure
-            - Enabled: true
+            # - Enabled: true
+            - Enabled: false
             - Enabled: false
         NodeToNodeEncryptionOptions:
           Fn::If:
             - BuildProdInfrastructure
-            - Enabled: true
+            # - Enabled: true
+            - Enabled: false
             - Enabled: false
         ElasticsearchVersion: 7.7
         DomainEndpointOptions:


### PR DESCRIPTION
We're reducing the production ES infrastructure to save on our own costs.
Real world, encryption would be on and instance size would be larger and scaled out.
The logic is all there for INFRASTRUCTURE_TYPE=production, so it should be obvious how to modify it