### PR TITLE
Update workflows for set-env deprecation

### DIFF
--- a/.github/build_vars.sh
+++ b/.github/build_vars.sh
@@ -20,13 +20,13 @@ set_value() {
   varname=${1}
   if [ ! -z "${!varname}" ]; then
     echo "Setting $varname"
-    echo "::set-env name=${varname}::${!varname}"
+    echo "${varname}=${!varname}" >> $GITHUB_ENV
   fi
 }
 
 set_name() {
   varname=${1}
-  echo "::set-env name=BRANCH_SPECIFIC_VARNAME_$varname::${branch_name//-/_}_$varname"
+  echo "BRANCH_SPECIFIC_VARNAME_$varname=${branch_name//-/_}_$varname" >> $GITHUB_ENV
 }
 
 action=${1}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set branch_name
-        run: echo "::set-env name=branch_name::${GITHUB_REF#refs/heads/}"
+        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Check branch name is a legal serverless stage name
         run: |
           if [[ ! $branch_name =~ ^[a-zA-Z][a-zA-Z0-9-]*$ ]] || [[ $branch_name -gt 128 ]]; then

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set branch_name
-        run: echo "::set-env name=branch_name::${{ github.event.ref }}"
+        run: echo "branch_name=${{ github.event.ref }}" >> $GITHUB_ENV
       - uses: actions/checkout@v1
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names


### PR DESCRIPTION
Closes #72 

See issues for details.  In short, Github Actions is deprecating set-env on Monday.  It was straightforward to move to an environment file.  The environment file approach is nearly identical to CircleCI.

There is no impact to how you are settings secrets and per-branch env variables.  The only difference is exactly how they are persisted throughout the build.  You do not need to make secrets updates on account of this PR.
