### PR TITLE
Add termination protection and refactor GHA caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,25 +55,10 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
-      - name: Combine yarn.lock files to single file
-        run: find services -maxdepth 3 -name yarn.lock | xargs cat yarn.lock > combined-yarn-lock.txt
-      - name: cache dependencies
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
-          path: |
-            services/database/node_modules
-            services/uploads/node_modules
-            services/app-api/node_modules
-            services/elasticsearch-auth/node_modules
-            services/elasticsearch/node_modules
-            services/elasticsearch-config/node_modules
-            services/stream-functions/node_modules
-            services/ui-auth/node_modules
-            services/ui/node_modules
-            services/ui-src/node_modules
-            node_modules
-            tests/nightwatch/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('combined-yarn-lock.txt') }}
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV

--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -18,7 +18,8 @@
     "serverless-offline": "^6.8.0",
     "serverless-plugin-scripts": "^1.0.2",
     "serverless-plugin-warmup": "^4.9.0",
-    "serverless-associate-waf": "^1.2.1"
+    "serverless-associate-waf": "^1.2.1",
+    "serverless-stack-termination-protection": "^1.0.4"
   },
   "dependencies": {
     "aws-sdk": "^2.788.0",

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -12,12 +12,23 @@ plugins:
   - serverless-plugin-scripts
   - serverless-associate-waf
   - serverless-offline
+  - serverless-stack-termination-protection
 
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   iamPath: ${ssm:/configuration/${self:custom.stage}/iam/path~true, ssm:/configuration/default/iam/path~true, "/"}
   iamPermissionsBoundaryPolicy: ${ssm:/configuration/${self:custom.stage}/iam/permissionsBoundaryPolicy~true, ssm:/configuration/default/iam/permissionsBoundaryPolicy~true, ""}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   infrastructureType: ${ssm:/configuration/${self:custom.stage}/infrastucture/type~true, ssm:/configuration/default/infrastucture/type~true, "development"}
   tableName: ${env:AMENDMENTS_TABLE_NAME, cf:database-${self:custom.stage}.AmendmentsTableName}
   tableArn: ${env:AMENDMENTS_TABLE_ARN, cf:database-${self:custom.stage}.AmendmentsTableArn}

--- a/services/app-api/yarn.lock
+++ b/services/app-api/yarn.lock
@@ -7634,6 +7634,11 @@ serverless-plugin-warmup@^4.9.0:
   dependencies:
     fs-extra "^9.0.0"
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==
+
 serverless-webpack@^5.3.1:
   version "5.3.5"
   resolved "https://registry.yarnpkg.com/serverless-webpack/-/serverless-webpack-5.3.5.tgz#3148433752893e9a91c6101dda78718a414e182e"

--- a/services/database/package.json
+++ b/services/database/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "CC0-1.0",
   "devDependencies": {
-    "serverless-dynamodb-local": "^0.2.39"
+    "serverless-dynamodb-local": "^0.2.39",
+    "serverless-stack-termination-protection": "^1.0.4"
   }
 }

--- a/services/database/serverless.yml
+++ b/services/database/serverless.yml
@@ -4,10 +4,21 @@ frameworkVersion: "2"
 
 plugins:
   - serverless-dynamodb-local
+  - serverless-stack-termination-protection
 
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   tableName: ${self:custom.stage}-amendments
   dynamodb:
     stages:

--- a/services/database/yarn.lock
+++ b/services/database/yarn.lock
@@ -700,6 +700,11 @@ serverless-dynamodb-local@^0.2.39:
     dynamodb-localhost "0.0.9"
     lodash "^4.17.0"
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"

--- a/services/elasticsearch-auth/package.json
+++ b/services/elasticsearch-auth/package.json
@@ -7,5 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "CC0-1.0"
+  "license": "CC0-1.0",
+  "devDependencies": {
+    "serverless-stack-termination-protection": "^1.0.4"
+  }
 }

--- a/services/elasticsearch-auth/serverless.yml
+++ b/services/elasticsearch-auth/serverless.yml
@@ -10,11 +10,24 @@ provider:
   runtime: nodejs12.x
   region: us-east-1
 
+plugins:
+  - serverless-stack-termination-protection
+
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   iamPath: ${ssm:/configuration/${self:custom.stage}/iam/path~true, ssm:/configuration/default/iam/path~true, "/"}
   iamPermissionsBoundaryPolicy: ${ssm:/configuration/${self:custom.stage}/iam/permissionsBoundaryPolicy~true, ssm:/configuration/default/iam/permissionsBoundaryPolicy~true, ""}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   sesSourceEmailAddress: ${ssm:/configuration/${self:custom.stage}/sesSourceEmailAddress~true, ssm:/configuration/default/sesSourceEmailAddress~true, ""}
 
 resources:

--- a/services/elasticsearch-auth/yarn.lock
+++ b/services/elasticsearch-auth/yarn.lock
@@ -2,3 +2,7 @@
 # yarn lockfile v1
 
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==

--- a/services/elasticsearch/package.json
+++ b/services/elasticsearch/package.json
@@ -7,5 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "CC0-1.0"
+  "license": "CC0-1.0",
+  "devDependencies": {
+    "serverless-stack-termination-protection": "^1.0.4"
+  }
 }

--- a/services/elasticsearch/serverless.yml
+++ b/services/elasticsearch/serverless.yml
@@ -10,11 +10,24 @@ provider:
   runtime: nodejs12.x
   region: us-east-1
 
+plugins:
+  - serverless-stack-termination-protection
+
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   iamPath: ${ssm:/configuration/${self:custom.stage}/iam/path~true, ssm:/configuration/default/iam/path~true, "/"}
   iamPermissionsBoundaryPolicy: ${ssm:/configuration/${self:custom.stage}/iam/permissionsBoundaryPolicy~true, ssm:/configuration/default/iam/permissionsBoundaryPolicy~true, ""}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   infrastructureType: ${ssm:/configuration/${self:custom.stage}/infrastucture/type~true, ssm:/configuration/default/infrastucture/type~true, "development"}
   cognito_identity_pool_id: ${cf:elasticsearch-auth-${self:custom.stage}.IdentityPoolId}
   cognito_identity_pool_authenticated_role_arn: ${cf:elasticsearch-auth-${self:custom.stage}.IdentityPoolAuthenticatedRoleArn}

--- a/services/elasticsearch/yarn.lock
+++ b/services/elasticsearch/yarn.lock
@@ -2,3 +2,7 @@
 # yarn lockfile v1
 
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==

--- a/services/stream-functions/package.json
+++ b/services/stream-functions/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "serverless-bundle": "^3.0.0",
-    "serverless-dotenv-plugin": "^3.0.0"
+    "serverless-dotenv-plugin": "^3.0.0",
+    "serverless-stack-termination-protection": "^1.0.4"
   }
 }

--- a/services/stream-functions/serverless.yml
+++ b/services/stream-functions/serverless.yml
@@ -8,6 +8,7 @@ package:
 plugins:
   - serverless-bundle
   - serverless-dotenv-plugin
+  - serverless-stack-termination-protection
 
 provider:
   name: aws
@@ -19,6 +20,16 @@ custom:
   region: ${opt:region, self:provider.region}
   iamPath: ${ssm:/configuration/${self:custom.stage}/iam/path~true, ssm:/configuration/default/iam/path~true, "/"}
   iamPermissionsBoundaryPolicy: ${ssm:/configuration/${self:custom.stage}/iam/permissionsBoundaryPolicy~true, ssm:/configuration/default/iam/permissionsBoundaryPolicy~true, ""}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   tableStreamArn: ${cf:database-${self:custom.stage}.AmendmentsTableStreamArn}
   elasticSearchDomainEndpoint: ${cf:elasticsearch-${self:custom.stage}.ElasticSearchDomainEndpoint}
   elasticSearchDomainArn: ${cf:elasticsearch-${self:custom.stage}.ElasticSearchDomainArn}

--- a/services/stream-functions/yarn.lock
+++ b/services/stream-functions/yarn.lock
@@ -6691,6 +6691,11 @@ serverless-dotenv-plugin@^3.0.0:
     dotenv "^8.2.0"
     dotenv-expand "^5.1.0"
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==
+
 serverless-webpack@^5.3.1:
   version "5.3.5"
   resolved "https://registry.yarnpkg.com/serverless-webpack/-/serverless-webpack-5.3.5.tgz#3148433752893e9a91c6101dda78718a414e182e"

--- a/services/ui-auth/package.json
+++ b/services/ui-auth/package.json
@@ -7,5 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "CC0-1.0"
+  "license": "CC0-1.0",
+  "devDependencies": {
+    "serverless-stack-termination-protection": "^1.0.4"
+  }
 }

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -7,11 +7,24 @@ provider:
   runtime: nodejs12.x
   region: us-east-1
 
+plugins:
+  - serverless-stack-termination-protection
+
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
   iamPath: ${ssm:/configuration/${self:custom.stage}/iam/path~true, ssm:/configuration/default/iam/path~true, "/"}
   iamPermissionsBoundaryPolicy: ${ssm:/configuration/${self:custom.stage}/iam/permissionsBoundaryPolicy~true, ssm:/configuration/default/iam/permissionsBoundaryPolicy~true, ""}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   sesSourceEmailAddress: ${ssm:/configuration/${self:custom.stage}/sesSourceEmailAddress~true, ssm:/configuration/default/sesSourceEmailAddress~true, ""}
   attachments_bucket_arn: ${cf:uploads-${self:custom.stage}.AttachmentsBucketArn}
   api_gateway_rest_api_name: ${cf:app-api-${self:custom.stage}.ApiGatewayRestApiName}

--- a/services/ui-auth/yarn.lock
+++ b/services/ui-auth/yarn.lock
@@ -2,3 +2,7 @@
 # yarn lockfile v1
 
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "serverless-cloudfront-invalidate": "^1.5.0",
     "serverless-plugin-scripts": "^1.0.2",
-    "serverless-s3-sync": "^1.14.4"
+    "serverless-s3-sync": "^1.14.4",
+    "serverless-stack-termination-protection": "^1.0.4"
   }
 }

--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -6,6 +6,7 @@ plugins:
   - serverless-plugin-scripts
   - serverless-s3-sync
   - serverless-cloudfront-invalidate
+  - serverless-stack-termination-protection
 
 provider:
   name: aws
@@ -15,6 +16,16 @@ provider:
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   api_region: ${cf:app-api-${self:custom.stage}.Region}
   api_url: ${cf:app-api-${self:custom.stage}.ApiGatewayRestApiUrl}
   cognito_region: ${cf:ui-auth-${self:custom.stage}.Region}

--- a/services/ui-src/yarn.lock
+++ b/services/ui-src/yarn.lock
@@ -11472,6 +11472,11 @@ serverless-s3-sync@^1.14.4:
     mime "^2.4.4"
     minimatch "^3.0.4"
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -8,5 +8,7 @@
   },
   "author": "",
   "license": "CC0-1.0",
-  "dependencies": {}
+  "devDependencies": {
+    "serverless-stack-termination-protection": "^1.0.4"
+  }
 }

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -7,9 +7,22 @@ provider:
   runtime: nodejs12.x
   region: us-east-1
 
+plugins:
+  - serverless-stack-termination-protection
+
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   route53HostedZoneId: ${ssm:/configuration/${self:custom.stage}/route53/hostedZoneId~true, ssm:/configuration/default/route53/hostedZoneId~true, ""}
   route53DomainName: ${ssm:/configuration/${self:custom.stage}/route53/domainName~true, ""}
   cloudfrontCertificateArn: ${ssm:/configuration/${self:custom.stage}/cloudfront/certificateArn~true, ssm:/configuration/default/cloudfront/certificateArn~true, ""}

--- a/services/ui/yarn.lock
+++ b/services/ui/yarn.lock
@@ -2,3 +2,7 @@
 # yarn lockfile v1
 
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==

--- a/services/uploads/package.json
+++ b/services/uploads/package.json
@@ -10,6 +10,7 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "serverless-plugin-scripts": "^1.0.2",
-    "serverless-s3-local": "^0.6.7"
+    "serverless-s3-local": "^0.6.7",
+    "serverless-stack-termination-protection": "^1.0.4"
   }
 }

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: "2"
 plugins:
   - serverless-plugin-scripts
   - serverless-s3-local
+  - serverless-stack-termination-protection
 
 provider:
   name: aws
@@ -16,6 +17,16 @@ custom:
   region: ${opt:region, self:provider.region}
   iamPath: ${ssm:/configuration/${self:custom.stage}/iam/path~true, ssm:/configuration/default/iam/path~true, "/"}
   iamPermissionsBoundaryPolicy: ${ssm:/configuration/${self:custom.stage}/iam/permissionsBoundaryPolicy~true, ssm:/configuration/default/iam/permissionsBoundaryPolicy~true, ""}
+  serverlessTerminationProtection:
+    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
+      - master
+      - val
+      - production
+      - develop
+      - main
+      - impl
+      - val
+      - prod
   scripts:
     hooks:
       # This script is run locally when running 'serverless deploy'

--- a/services/uploads/yarn.lock
+++ b/services/uploads/yarn.lock
@@ -2039,6 +2039,11 @@ serverless-s3-local@^0.6.7:
     serverless-offline "^6.5.0"
     shelljs "^0.8.3"
 
+serverless-stack-termination-protection@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/serverless-stack-termination-protection/-/serverless-stack-termination-protection-1.0.4.tgz#e0430108cfc8f4d72a63138ef5781c6fe9707868"
+  integrity sha512-2uOF6/t90VXpWq8ZbWgEXMiYXA+9ZKsgm8or5jJLQYnm0Sbu2z7/EK2/ACwH4uaErFOdprI0tO9H8STdKK4TFQ==
+
 set-immediate-shim@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"


### PR DESCRIPTION
Closes #113 
Closes #107 

This adds cloudformation termination protection for a list of stage names that are commonly used for important environments.  This has the effect of requiring a --force flag to be set if destroying a protected stage with serverless (something we never do programatically, so a human would need to set that).  In the console, to delete a protected stack, the termination protection must be manually edited to be disabled. 
We have a few safeguards in place to prevent deletion of important stages, but this is a huge add since it's protection baked into cloudformation itself.
```  serverlessTerminationProtection:
    stages: # This is a list of common names for important envs that should not be destroyed.  You can remove the stage names your project doesn't use; this list is meant to be inclusive.
      - master
      - val
      - production
      - develop
      - main
      - impl
      - val
      - prod
 ```
 Obviously a project only needs to protect the stages it cares about (usually master, val, production), but I added all that we've seen to be more safe than sorry.

The github actions caching logic was also refactored.  Same end result, just less code and less things to update when adding a new service. 

See issues for more detail.