### PR TITLE
Add CI support for Dependabot auto-generated security updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: set branch_name
         run: |
           if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10`" >> $GITHUB_ENV
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10 | sed 's/^/dep-/'`" >> $GITHUB_ENV
           else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "*"
+      - "dependabot/**"
+      - "!dependabot"
       - "!skipci*"
 
 jobs:
@@ -11,7 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set branch_name
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # If this is a Dependabot generated branch, set branch_name to 'dependabot'.
+            echo "branch_name=dependabot" >> $GITHUB_ENV
+          else # Else set branch_name to this branch's name, but without the refs/heads/ prefix.
+            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
       - name: Check branch name is a legal serverless stage name
         run: |
           if [[ ! $branch_name =~ ^[a-zA-Z][a-zA-Z0-9-]*$ ]] || [[ $branch_name -gt 128 ]]; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: set branch_name
         run: |
           if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10 | sed 's/^/dep-/'`" >> $GITHUB_ENV
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
           else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "*"
       - "dependabot/**"
-      - "!dependabot"
       - "!skipci*"
 
 jobs:
@@ -14,9 +13,9 @@ jobs:
     steps:
       - name: set branch_name
         run: |
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # If this is a Dependabot generated branch, set branch_name to 'dependabot'.
-            echo "branch_name=dependabot" >> $GITHUB_ENV
-          else # Else set branch_name to this branch's name, but without the refs/heads/ prefix.
+          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10`" >> $GITHUB_ENV
+          else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi
       - name: Check branch name is a legal serverless stage name

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: set branch_name
         run: |
           if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
           else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: set branch_name
         run: |
           if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10 | sed 's/^/dep-/'`" >> $GITHUB_ENV
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
           else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: set branch_name
         run: |
           if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
           else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: set branch_name
         run: |
           if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10`" >> $GITHUB_ENV
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10 | sed 's/^/dep-/'`" >> $GITHUB_ENV
           else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -13,7 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: set branch_name
-        run: echo "branch_name=${{ github.event.ref }}" >> $GITHUB_ENV
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # If this is a Dependabot generated branch, set branch_name to 'dependabot'.
+            echo "branch_name=dependabot" >> $GITHUB_ENV
+          else # Else set branch_name to this branch's name, but without the refs/heads/ prefix.
+            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v1
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - name: set branch_name
         run: |
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # If this is a Dependabot generated branch, set branch_name to 'dependabot'.
-            echo "branch_name=dependabot" >> $GITHUB_ENV
-          else # Else set branch_name to this branch's name, but without the refs/heads/ prefix.
+          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5 | head -c 10`" >> $GITHUB_ENV
+          else
             echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v1


### PR DESCRIPTION
## Purpose

This PR enables our standard CI support for dependency security updates that are automatically generated by Dependabot.

#### Linked Issues to Close

Closes #133 

## Approach

[Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) is a GitHub native tool that is capable of scanning source code for package vulnerabilities.  Once enabled, Dependabot will scan the default branch for listed dependencies in package.json and yarn.lock files.  If a vulnerable package version is detected, Dependabot will publish a security alert, visible to repository/org admins in the GItHub UI.  Enabling automatic security updates is also an option for Dependabot; with this enabled, Dependabot will try to make the suggested fix on a branch and open a PR for that branch.  This automatic Dependabot security update workflow is what this PR is about.  

Currently, without these changes, dependabot branches are not deployed and tested in GitHub Actions.  The deploy workflow's 'on' block, which defines when the workflow runs, only lists "*".  Since dependabot branches are put underneath the "dependabot/" namespace (for example:  dependabot/npm_and_yarn/services/ui-src/y18n-4.0.1), the simple wildcard does not match, and Dependabot branches are not built.  This is a problem, as we cannot accept undeployed and untested changes.

This PR updates that "on" block to build branches that are underneath the "dependabot/" namespace.  The approach taken and the highlights are:
- The "on" block filters in the deploy.yml workflow was appended to build anything matching "dependabot/**".  This enables the workflow for all branches that begin with "dependabot/".
- Logic was added to change how we set the serverless stage name for dependabot branches.  Because Dependabot branches are so long and contain special characters, it is problematic to use the entire unique branch name.  The switch, as seen in both deploy.yml and destroy.yml, sets the branch_name variable (which drives the serverless stage name) to the first 10 characters of the md5 checksum.  An "x" is prepended to the checksum, to ensure the stage name will begin with a letter, which is a requirement for Serverless stage names.

With this logic, each Dependabot automatic update will be deployed and tested just like any other branch.  If our deployment and test phase succeeds, we should feel confident in merging the Dependabot generated PR.

## Learning

The big learn was that Dependabot doesn't fork, it creates a branch.

## Assorted Notes/Considerations

- Dependabot cannot create automated updates for *all* alerts it publishes.  If the vulnerable package version is a sub dependency of a package that we have explicitly locked, Dependabot cannot make the update, by design.  This isn't specific to this tool (dependabot) or this implementation... this is intended behavior.  For updates that cannot be made automatically, standard development process should make the update (make an issue, make a branch, update the locked package, make a PR).
- Dependabot will automatically delete the upstream branch after PR merge.  I think I read it waits 10 seconds after merge, then deletes the upstream.  This is desired behavior, as the Dependabot environments and code need not stick around.
- Using the first 10 characters of the md5 hash of the branch name is not a [perfect hash function](https://en.wikipedia.org/wiki/Perfect_hash_function).  However, it will practically always generate unique values, and works for our uses here.  A collision, while extremely unlikely, would simply cause two branches to operate against the same environment.  While this is not ideal, it's not dangerous; our lock script prevents multiple operations being run concurrently against the same stage.

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
