### PR TITLE
Bug fix - Correct destroy functionality. 

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: set branch_name
         run: |
-          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
-            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
+          if [[ "${{ github.event.ref }}" =~ ^dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
+            echo "branch_name=`echo ${{ github.event.ref }} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
           else
-            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+            echo "branch_name=${{ github.event.ref }}" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v1
       - name: set branch specific variable names


### PR DESCRIPTION

## Purpose

Fixes a bug around destroy functionality, introduced by #140 

#### Linked Issues to Close

#141 

## Approach

The fix is pretty apparent if you look at the destroy.yml diff in #140 
When destroying, the branch on which the action is running is always the default branch (master).
The way in which you find the name of the branch that was deleted differs from deploy.yml (which runs on the target branch).
This PR fixes this error.

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
