### PR TITLE
Fix incorrect branch locking behavior for Destroy workflow

### DIFF
--- a/.github/github-lock.sh
+++ b/.github/github-lock.sh
@@ -7,7 +7,11 @@ set -e -o xtrace -o errexit -o pipefail -o nounset -u
 # It prevents conurrent deployments on the same branch
 ########################################################################################
 
-branch=${GITHUB_REF#refs/heads/}
+if [[ $# -eq 0 ]] ; then
+  echo 'ERROR:  You must pass the name of the branch to lock to the github-lock script.'
+  exit 1
+fi
+branch=${1}
 rest=()
 github_base_url="api.github.com"
 api_url="https://$github_base_url/repos/$GITHUB_REPOSITORY/actions/runs?status=in_progress&branch=$branch"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       - name: lock this branch to prevent concurrent builds
-        run: ./.github/github-lock.sh
+        run: ./.github/github-lock.sh $branch_name
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: read .nvmrc

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -30,7 +30,7 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
       - name: lock this branch to prevent concurrent builds
-        run: ./.github/github-lock.sh
+        run: ./.github/github-lock.sh $branch_name
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: ./destroy.sh $STAGE_PREFIX$branch_name


### PR DESCRIPTION
## Purpose

This changeset fixes the incorrect branch locking behavior seen when the Destroy workflow runs.  Without this changeset, the Destroy workflow will always (pretty harmlessly) lock against the master branch.

#### Linked Issues to Close

Closes #144 

## Approach

The [github-lock.sh script](https://github.com/CMSgov/macpro-quickstart-serverless/blob/master/.github/github-lock.sh) plays an important role in our Deploy and Destroy workflows.  It's purpose is to prevent concurrent deploys or destroys against a single set of infrastructure.  For example, if someone pushes a change to the _mydev_ branch, a deployment will start that will build/configure the application in AWS; if someone pushes another change to _mydev_ before the first deployment finishes, you have potential for unpredictable behavior as two deployments are deploying against the same infrastructure.  This is where the lock script helps.  When run, the lock script:
- Determines the branch name on which deploy/destroy is running.  There's an implicit assumption that branch name maps to stage name, so the branch name uniquely identifies the set of infrastructure deploy/destroy will touch.
- Determines its build number.
- Polls the GitHub API for any builds on the same branch with a build number less than its own.
- Waits until there are no earlier builds for its branch.
In this way, the lock script makes a queue for concurrent builds.

This works as intended for the deploy workflow, but there's an issue running it for destroy.

When a workflow, Destroy in this case, is triggered from a delete event, the build runs on the default branch (master).  This makes sense... if you're trying to run a workflow when the _dev_ branch is deleted, it couldn't possibly run on the _dev_ branch, because it no longer exists.
Since delete triggered workflows run on the default branch, the first bullet in the above list is incorrect.  When the current script (without these changes) tries to determine the branch for the destroy workflow, it always resolves to the default branch.  

This changeset fixes that behavior.  The same logic used in destroy.yml to set the branch_name is leveraged here.  We simply pass the correct branch name (the name of the branch that was deleted) to the lock script.  The deploy workflow, the only other user of the lock script, is updated to pass the branch name as well.

Here's the Destroy workflow running before this PR's changes, when deleting the _branchtodelete_ branch (note the log that says branch=master):
<img width="1421" alt="Screen Shot 2021-04-12 at 10 29 00 AM" src="https://user-images.githubusercontent.com/48921055/114415219-7caf1b80-9b7d-11eb-8937-fbdf43274a86.png">

Here's the Destroy workflow running with this PR's changes, when deleting _branchtodelete_ (note branch=branchtodelete in the logs)
<img width="1415" alt="Screen Shot 2021-04-12 at 10 31 05 AM" src="https://user-images.githubusercontent.com/48921055/114415309-92244580-9b7d-11eb-8415-aabcf4c9a8bc.png">


## Learning

The GitHub [docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#delete) explain that delete events run on the default branch, which was the root cause of the issue.

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
