### PR TITLE
Enable lambda warmup for all Envs

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -34,18 +34,16 @@ custom:
   tableArn: ${env:AMENDMENTS_TABLE_ARN, cf:database-${self:custom.stage}.AmendmentsTableArn}
   atomicCounterTableName: ${env:AMENDMENTS_COUNTER_TABLE_NAME, cf:database-${self:custom.stage}.AmendmentsAtomicCounterTableName}
   atomicCounterTableArn: ${env:AMENDMENTS_COUNTER_TABLE_ARN, cf:database-${self:custom.stage}.AmendmentsAtomicCounterTableArn}
-  warmupEnabled:
-    production: true
-    development: false
+
   warmup:
-    enabled: ${self:custom.warmupEnabled.${self:custom.infrastructureType}}
+    enabled: true
     role: LambdaWarmupRole
     vpc: false
     events:
-      - schedule: rate(4 minutes)
+      - schedule: ${ssm:/configuration/${self:custom.stage}/warmup/schedule~true, ssm:/configuration/default/warmup/schedule~true, rate(4 minutes)}
     timeout: 20
     prewarm: true
-    concurrency: 5
+    concurrency: ${ssm:/configuration/${self:custom.stage}/warmup/concurrency~true, ssm:/configuration/default/warmup/concurrency~true, 5}
     folderName: node_modules/serverless-bundle/src/_warmup
     cleanFolder: false
   scripts:

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -40,7 +40,7 @@ custom:
     role: LambdaWarmupRole
     vpc: false
     events:
-      - schedule: ${ssm:/configuration/${self:custom.stage}/warmup/schedule~true, ssm:/configuration/default/warmup/schedule~true, rate(4 minutes)}
+      - schedule: rate(${ssm:/configuration/${self:custom.stage}/warmup/schedule~true, ssm:/configuration/default/warmup/schedule~true, "4 minutes"})
     timeout: 20
     prewarm: true
     concurrency: ${ssm:/configuration/${self:custom.stage}/warmup/concurrency~true, ssm:/configuration/default/warmup/concurrency~true, 5}


### PR DESCRIPTION
## Purpose
The purpose of this fix it to resolve warmup issue encountered in higher environment, when lambda failed to deploy.
The root cause is that the warmup plugin's enablement is conditional. Currently, the deploy looks for an SSM parameter that indicates a generic "infrastructure type". By default, warmup is disabled in lower environment and enabled in higher environments.
To resolve the issue, there should be global enablement of warmup, But setting the configuration of warmup should still be configurable

#### Linked Issues to Close

Closes #171 

## Approach

The current logic to enable/disable warmup should be removed.
The configuration of warmup should have defaults but be configurable via SSM. So, warmup can never be shut off, but we can optionally warmup more or often.

## Learning

Reviewed the following GitHub pages to understand the issue better and reolve issue
https://github.com/CMSgov/macpro-quickstart-serverless/blob/master/services/app-api/serverless.yml#L32
https://github.com/CMSgov/macpro-quickstart-serverless/issues/171
https://github.com/CMSgov/macpro-quickstart-serverless/blob/master/services/app-api/serverless.yml#L44-L48

## Assorted Notes/Considerations

_List any other information that you think is important... a post-merge activity, someone to notify, etc._

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
