### PR TITLE
 Make Code climate upload conditional and archive coverage file

### DIFF
--- a/.github/build_vars.sh
+++ b/.github/build_vars.sh
@@ -6,6 +6,7 @@ var_list=(
   'AWS_DEFAULT_REGION'
   'STAGE_PREFIX'
   'SLACK_WEBHOOK_URL'
+  'CODE_CLIMATE_ID'
 )
 
 set_value() {

--- a/.github/build_vars.sh
+++ b/.github/build_vars.sh
@@ -6,7 +6,6 @@ var_list=(
   'AWS_DEFAULT_REGION'
   'STAGE_PREFIX'
   'SLACK_WEBHOOK_URL'
-  'CODE_CLIMATE_ID'
 )
 
 set_value() {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,11 +61,10 @@ jobs:
           coverageLocations: |
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: Store unit test reults
-          # if: env.CODE_CLIMATE_ID = ''
-          uses: actions/upload-artifact@v2
-          with:
-            name: unit_test_results
-            path: ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit_test_results
+          path: ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: deploy
         run: |
           # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: lock this branch to prevent concurrent builds
         run: ./.github/github-lock.sh $branch_name
         env:
@@ -50,7 +51,9 @@ jobs:
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
-      - name: publish coverage
+      - name: publish test coverage to code climate
+        # only publish code coverage if CODE_CLIMATE_ID is set
+        if: env.CODE_CLIMATE_ID != ''
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,14 +52,12 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        # only publish code coverage if CODE_CLIMATE_ID is set
         if: env.CODE_CLIMATE_ID != ''
         uses: paambaati/codeclimate-action@v2.7.5
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
+          CC_TEST_REPORTER_ID: env.CODE_CLIMATE_ID
         with:
           debug: true
-          # coverageCommand: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
           coverageLocations: |
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,8 @@ jobs:
         # if: env.CODE_CLIMATE_ID != ''
         uses: paambaati/codeclimate-action@v2.7.5
         env:
-          CC_TEST_REPORTER_ID: env.CODE_CLIMATE_ID
+          # CC_TEST_REPORTER_ID: env.CODE_CLIMATE_ID
+          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
         with:
           debug: true
           coverageLocations: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        if: env.CODE_CLIMATE_ID == 'something'
+        if: env.CODE_CLIMATE_ID != ''
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,15 @@ jobs:
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-      - name: unit test & publish coverage
+      - name: run unit tests
+        run: /test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
+      - name: publish coverage
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
         with:
           debug: true
-          coverageCommand: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
+          # coverageCommand: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
           coverageLocations: |
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        if: env.CODE_CLIMATE_ID != ''
+        # if: env.CODE_CLIMATE_ID != ''
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: env.CODE_CLIMATE_ID

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        if: env.CODE_CLIMATE_ID = "something"
+        if: env.CODE_CLIMATE_ID == "something"
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        if: env.CODE_CLIMATE_ID == "something"
+        if: env.CODE_CLIMATE_ID == 'something'
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: lock this branch to prevent concurrent builds
         run: ./.github/github-lock.sh $branch_name
         env:
@@ -51,7 +52,7 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        if: ${{ secrets.CODE_CLIMATE_ID }} != ''
+        if: env.CODE_CLIMATE_ID != ''
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,12 @@ jobs:
           debug: true
           coverageLocations: |
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
+      - name: Store unit test reults
+          # if: env.CODE_CLIMATE_ID = ''
+          uses: actions/upload-artifact@v2
+          with:
+            name: unit_test_results
+            path: ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: deploy
         run: |
           # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,6 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets[env.BRANCH_SPECIFIC_VARNAME_AWS_DEFAULT_REGION] || secrets.AWS_DEFAULT_REGION }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          CODE_CLIMATE_ID: ${{ secrets.CODE_CLIMATE_ID }}
       - name: lock this branch to prevent concurrent builds
         run: ./.github/github-lock.sh $branch_name
         env:
@@ -52,10 +51,8 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        # if: env.CODE_CLIMATE_ID != ''
         uses: paambaati/codeclimate-action@v2.7.5
         env:
-          # CC_TEST_REPORTER_ID: env.CODE_CLIMATE_ID
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
         with:
           debug: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
+        if: ${{ secrets.CODE_CLIMATE_ID }} != ''
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        if: env.CODE_CLIMATE_ID != ''
+        if: env.CODE_CLIMATE_ID = 'something'
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       - name: run unit tests
         run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish test coverage to code climate
-        if: env.CODE_CLIMATE_ID = 'something'
+        if: env.CODE_CLIMATE_ID = "something"
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: unit_test_results
-          path: ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
+          path: ${{github.workspace}}/services/ui-src/coverage/lcov.info
       - name: deploy
         run: |
           # When deploying multiple copies of this quickstart to the same AWS Account (not ideal), a prefix helps prevent stepping on each other.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
       - name: run unit tests
-        run: /test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
+        run: ./test-unit.sh {{ env.STAGE_PREFIX }}{{ env.branch_name }}
       - name: publish coverage
         uses: paambaati/codeclimate-action@v2.7.5
         env:


### PR DESCRIPTION
## Purpose

The purpose of this pull request is to allow unit tests to run within the pipeline without conceding that your repository must be wired to code climate.  Previously the stage was all in one (run unit tests, upload code coverage metrics). Now unit tests run first and the upload test coverage step is conditionally run based on an environment variable  (CODE_CLIMATE_ID) being set. If the env var is not set the step does not run. 

#### Linked Issues to Close

closes #221 

## Approach

Only run the "publish test coverage to code climate" step if the "CODE_CLIMATE_ID" env var is set.


#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
