### PR TITLE
Fixing syntax in ui-src/serverless.yml which prevented user creation 

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -40,7 +40,7 @@ custom:
   scripts:
     hooks:
       deploy:finalize: |
-        if [ ${self:custom.bootstrapUsersEnabled} == "true" ];
+        if [ ${self:custom.bootstrapUsersEnabled} = "true" ];
         then
           serverless invoke --stage ${self:custom.stage} --function bootstrapUsers
         fi

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -40,7 +40,8 @@ custom:
   scripts:
     hooks:
       deploy:finalize: |
-        if [ ${self:custom.bootstrapUsersEnabled} = "true" ];
+        set -e
+        if [ ${self:custom.bootstrapUsersEnabled} == "true" ];
         then
           serverless invoke --stage ${self:custom.stage} --function bootstrapUsers
         fi

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -40,8 +40,7 @@ custom:
   scripts:
     hooks:
       deploy:finalize: |
-        set -e
-        if [ ${self:custom.bootstrapUsersEnabled} == "true" ];
+        if [ ${self:custom.bootstrapUsersEnabled} = "true" ];
         then
           serverless invoke --stage ${self:custom.stage} --function bootstrapUsers
         fi


### PR DESCRIPTION
## Purpose

A change was pushed earlier https://github.com/CMSgov/macpro-quickstart-serverless/pull/215 which is meant to add users at deploy time.  However, this code was developed and deployed locally.  This worked developing locally and tested in the target branch. However, when pushed to the pipeline there are differences in the github runner and a local bash shell.  This is to fix that issue. 

#### Linked Issues to Close

closes #227 

## Approach

Fix syntax, push and let it run in the github runner. Log in and test in the cloudfront URL for the target environment. 


#### Pull Request Creator Checklist

- [ x] This PR has an associated issue or issues.
- [x ] The associated issue(s) are linked above.
- [x ] This PR meets all acceptance criteria for those issues.
- [x ] This PR and linked issue(s) are adequately documented
- [x ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x ] Someone has been assigned this PR.
- [ x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
