### PR TITLE
Enable encryption for the uploads service's buckets

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -88,8 +88,8 @@ resources:
         BucketName: !Sub ${self:service.name}-${self:custom.stage}-attachments-${AWS::AccountId}
         BucketEncryption:
           ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
         CorsConfiguration: # Set the CORS policy
           CorsRules:
             - AllowedOrigins:
@@ -162,8 +162,8 @@ resources:
         BucketName: !Sub ${self:service.name}-${self:custom.stage}-avscan-${AWS::AccountId}
         BucketEncryption:
           ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
         AccessControl: Private
     BucketAVScanRole:
       Type: "AWS::IAM::Role"

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -86,6 +86,10 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: !Sub ${self:service.name}-${self:custom.stage}-attachments-${AWS::AccountId}
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+            SSEAlgorithm: AES256
         CorsConfiguration: # Set the CORS policy
           CorsRules:
             - AllowedOrigins:
@@ -156,6 +160,10 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: !Sub ${self:service.name}-${self:custom.stage}-avscan-${AWS::AccountId}
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+            SSEAlgorithm: AES256
         AccessControl: Private
     BucketAVScanRole:
       Type: "AWS::IAM::Role"

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -89,7 +89,7 @@ resources:
         BucketEncryption:
           ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-            SSEAlgorithm: AES256
+              SSEAlgorithm: AES256
         CorsConfiguration: # Set the CORS policy
           CorsRules:
             - AllowedOrigins:
@@ -163,7 +163,7 @@ resources:
         BucketEncryption:
           ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-            SSEAlgorithm: AES256
+              SSEAlgorithm: AES256
         AccessControl: Private
     BucketAVScanRole:
       Type: "AWS::IAM::Role"


### PR DESCRIPTION
## Purpose

The quickstart application makes use of two buckets, both of which are deployed from the uploads service:

1. The attachments bucket this is where user uploads are stored.
2. The clamav definitions bucket: this holds clamAV vulnerability definitions, and is used as part of the virus scanning strategy.
Neither of these buckets are encrypted.

The purpose of this fix is to achieve the following acceptance criteria:
The attachments bucket in the uploads service has server-side encryption enabled.
The clamAV definitions bucket in the uploads service has server-side encryption enabled.

#### Linked Issues to Close

Closes #234 

## Approach

The approach to resolving the issue is by modifying the underlying CloudFormation code in the uploads services' serverless.yml file to enable encryption. The SS#-s3 encryption were enabled on the following two buckets in the code:
1. The attachments bucket 
2. The clamav definitions bucket

## Learning

Reviewed the following GitHub and blogs:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-encryption.html
https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-bucket-encryption.html

## Assorted Notes/Considerations

**Verification of encryption:**

1. Navigate to S3 dashboard at https://console.aws.amazon.com/s3/.
2. Search for the name of the following S3 buckets:
    - The attachments bucket 
    - The clamav definitions bucket
3. Select the Properties tab from the S3 dashboard top menu and check the Default encryption feature status. If the feature status is set to Disabled, the default encryption is not currently enabled, therefore the selected AWS S3 bucket does not encrypt automatically all objects at upload.

You can also run the following CLI command:
- Run get-bucket-encryption command using the name of the S3 buckets as identifier to retrieve the Default Encryption feature status for the selected bucket:
aws s3api get-bucket-encryption
	--bucket cloud-conformity-media

- The command output should return the requested feature configuration details or the ServerSideEncryptionConfigurationNotFoundError error message if the feature is not currently enabled:
"An error occurred (ServerSideEncryptionConfigurationNotFoundError) when calling the GetBucketEncryption operation: The server side encryption configuration was not found."

## POST-DEPLOY STEP:
Amazon S3’s default encryption is used to automate the encryption of new objects in the buckets for this change, but default encryption does not change the encryption of existing objects in the buckets. But there are other existing objects in the  S3 buckets that must be encrypted as well. Highlighted below are the steps to encrypt existing objects. Also provided are considerations and suggestions before performing the encryption of existing objects.


**STEPS TO PERFORM ENCRYPTION OF EXISTING OBJECTS USING AWS CLI:**
To encrypt existing objects in place, you can use the Copy Object or Copy Part API. This copies the objects with the same name and encrypts the object data using server-side encryption. 

1. Make sure AWS CLI is installed and configured.
2. List S3 buckets and identify the Buckets to perform encryption of objects on:
   **aws s3 ls**
3. To encrypt all objects in the Attachmentsbucket S3 bucket, run the following command:
**aws s3 cp s3://attachmentsbucket/ s3://attachmentsbucket/ --sse AES256 --recursive**
4. To encrypt all objects in the clamav definitions S3 bucket, run the following command:
**aws s3 cp s3://ClamDefsBucket/ s3://ClamDefsBucket/ --sse AES256 --recursive**


**SUGGESTIONS BEFORE PERFORMING ENCRYPTION OF EXISTING OBJECTS:**
1. Consider enabling S3 Versioning or other ways that you could revert this change.
2. Perform this on a subset of the data first before applying it to all the objects in the S3 bucket.
3. Consider setting up the S3 Inventory to monitor what are encrypted, as well as other details that you may want to consider.

**IMPORTANT NOTE/CONSIDERATIONS BEFORE ENCRYPTING EXISTING OBJECTS:**
1. Note that when you try to encrypt an existing object using SSE, you are replacing the object in-place. 
2. LastModified timestamp is changed to the timestamp of the copy. Applications that depend on object timestamps now  needs to look at the copy timestamp and not the original upload timestamp. 
3. Access Control List (ACL) is reset to the S3 bucket default. So, if Object ACLs are used, they must be added in the Copy Operation.
4. Custom metadata: you want to ensure that you are copying any custom metadata to the new objects using the --metadata parameter.
5. S3 object tags: the AWS CLI cp command does not copy object tags from the source object to the destination object. You can use the aws s3api put-object-tag command to add these to the new object.
6. Bucket versioning: in buckets that have versioning enabled this procedure creates a new version of the object that is encrypted, but does not modify the existing unencrypted object version.
7. The storage class defaults to STANDARD. If you want a different storage class, you can set this with --storage-class. 
8. Object Lock: If object lock is used,  the retention period is reset to the bucket default.


#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
