### PR TITLE
Implement HSTS on Cloudfront distribution - Lambda@Edge Approach

### DIFF
--- a/services/ui/handlers/hsts.js
+++ b/services/ui/handlers/hsts.js
@@ -1,0 +1,11 @@
+
+exports.handler = (event, context, callback) => {
+  if (event.source == "serverless-plugin-warmup") {
+    console.log("Warmed up!");
+    return null;
+  }
+  const response = event.Records[0].cf.response;
+  const headers = response.headers;
+  headers['strict-transport-security'] = [{key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubdomains; preload'}];
+  return callback(null, response);
+};

--- a/services/ui/handlers/hsts.js
+++ b/services/ui/handlers/hsts.js
@@ -1,4 +1,3 @@
-
 exports.handler = (event, context, callback) => {
   if (event.source == "serverless-plugin-warmup") {
     console.log("Warmed up!");
@@ -6,6 +5,11 @@ exports.handler = (event, context, callback) => {
   }
   const response = event.Records[0].cf.response;
   const headers = response.headers;
-  headers['strict-transport-security'] = [{key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubdomains; preload'}];
+  headers["strict-transport-security"] = [
+    {
+      key: "Strict-Transport-Security",
+      value: "max-age=63072000; includeSubdomains; preload",
+    },
+  ];
   return callback(null, response);
 };

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -9,6 +9,7 @@ provider:
   region: us-east-1
 
 plugins:
+  - serverless-plugin-warmup
   - serverless-stack-termination-protection
 
 custom:
@@ -31,7 +32,25 @@ custom:
   wafLoggingBucket: ${cf:ui-waflog-s3-bucket-${self:custom.stage}.WaflogsUploadBucketArn}
   iamPath: ${ssm:/configuration/${self:custom.stage}/iam/path~true, ssm:/configuration/default/iam/path~true, "/"}
   iamPermissionsBoundaryPolicy: ${ssm:/configuration/${self:custom.stage}/iam/permissionsBoundaryPolicy~true, ssm:/configuration/default/iam/permissionsBoundaryPolicy~true, ""}
-
+  warmup:
+    enabled: true
+    role: LambdaWarmupRole
+    vpc: false
+    events:
+      - schedule: rate(${ssm:/configuration/${self:custom.stage}/warmup/schedule~true, ssm:/configuration/default/warmup/schedule~true, "4 minutes"})
+    timeout: 20
+    prewarm: true
+    concurrency: ${ssm:/configuration/${self:custom.stage}/warmup/concurrency~true, ssm:/configuration/default/warmup/concurrency~true, 5}
+    folderName: node_modules/serverless-bundle/src/_warmup
+    cleanFolder: false
+functions:
+  hsts:
+    handler: handlers/hsts.handler
+    role: LambdaEdgeFunctionRole
+    events:
+      - cloudFront:
+          eventType: viewer-response
+          origin: s3://#{S3Bucket}.s3.amazonaws.com
 resources:
   Conditions:
     CreatePermissionsBoundary:
@@ -249,6 +268,68 @@ resources:
                       - CloudFrontDistribution
                       - DomainName
                   - "/"
+    LambdaEdgeFunctionRole: # Why isn't this with the function as an iamRoleStatements?  https://github.com/serverless/serverless/issues/6485
+      Type: "AWS::IAM::Role"
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Principal:
+                Service:
+                  - "lambda.amazonaws.com"
+                  - "edgelambda.amazonaws.com"
+              Action: "sts:AssumeRole"
+        Path: ${self:custom.iamPath}
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - !Sub arn:aws:iam::${AWS::AccountId}:policy${self:custom.iamPermissionsBoundaryPolicy}
+            - !Ref AWS::NoValue
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        Policies:
+          - PolicyName: "LambdaApiRolePolicy"
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: "Allow"
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource: "arn:aws:logs:*:*:*"
+    LambdaWarmupRole:
+      Type: "AWS::IAM::Role"
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Principal:
+                Service: "lambda.amazonaws.com"
+              Action: "sts:AssumeRole"
+        Path: ${self:custom.iamPath}
+        PermissionsBoundary:
+          Fn::If:
+            - CreatePermissionsBoundary
+            - !Sub arn:aws:iam::${AWS::AccountId}:policy${self:custom.iamPermissionsBoundaryPolicy}
+            - !Ref AWS::NoValue
+        Policies:
+          - PolicyName: "Warmup"
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: "Allow"
+                  Action:
+                    - logs:CreateLogGroup
+                    - logs:CreateLogStream
+                    - logs:PutLogEvents
+                  Resource: "arn:aws:logs:*:*:*"
+                - Effect: "Allow"
+                  Action:
+                    - lambda:InvokeFunction
+                  Resource: "*"
   Outputs:
     S3BucketName:
       Value: !Ref S3Bucket


### PR DESCRIPTION
## Purpose

This implements HTTP Strict Transport Security on our applications frontend Cloudfront Distribution and meets a compliance requirement

#### Linked Issues to Close

Closes #244

## Approach

This issue was to implement HTTP Strict Transport Security for our web application.  Our frontend is a static React website hosted in S3 and fronted by Cloudfront.  Implementing it is possible using Lambda@Edge.
This changeset adds a lambda function and appropriate "plumbing" to add a header to all responses from our Cloudfront Distribution.  The "strict-transport-security" header is added to all responses from the distribution.

Guides used:
- [AWS Guide for HSTS using Lambda@Edge and Amazon CloudFront](https://aws.amazon.com/blogs/networking-and-content-delivery/adding-http-security-headers-using-lambdaedge-and-amazon-cloudfront/)
- [Serverless Lambda@Edge support](https://www.serverless.com/blog/lambda-at-edge-support-added)

Following the guides above, a new lambda named 'hsts' was added to the ui service.  Lambda functions can be set to trigger off any of [four Cloudfront events](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-cloudfront-trigger-events.html).  To be compliant, we want to add an HSTS header to the response before we reply to the caller.  So, the hsts function was set to trigger off the "viewer-response" event.  The business logic of the hsts function is simple... it adds the strict-transport-security header with the following snippet:
```
headers["strict-transport-security"] = [
  {
    key: "Strict-Transport-Security",
    value: "max-age=63072000; includeSubdomains; preload",
  },
];
```
The difference in the response header can be seen using browser (chrome, in my case) inspection tools, and it can be compared to master to verify it's working.  See screenshots below.

The deployed environment for this branch had an unauthenticated scan performed by our security asset, Eric, and no HSTS issues were found.

## Learning

The guides listed above were followed and translated to Serverless Framework.

## Assorted Notes/Considerations

The pattern of a Lambda@Edge firing on Cloudfront events offers the opportunity to add any headers we'd like.  This issue was scoped to HSTS, so we're just adding that header.

Screenshots:
_response headers from the current master environment, without hsts_
<img width="1286" alt="Screen Shot 2021-05-27 at 11 20 07 AM" src="https://user-images.githubusercontent.com/48921055/119976450-1b080c80-bf85-11eb-805f-1943b191d13e.png">

_response headers from this branch's environment, with the hsts header added_
<img width="1439" alt="Screen Shot 2021-05-27 at 11 20 54 AM" src="https://user-images.githubusercontent.com/48921055/119976494-2824fb80-bf85-11eb-93d2-384ba9b9e6d7.png">


#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
