### PR TITLE
Implement HSTS on Cloudfront distribution - CloudFront Functions approach

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -141,6 +141,9 @@ resources:
               Cookies:
                 Forward: none
             ViewerProtocolPolicy: redirect-to-https
+            FunctionAssociations:
+              - EventType: viewer-response
+                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN
           ViewerCertificate:
             Fn::If:
               - CreateCustomCloudFrontDomain
@@ -164,6 +167,21 @@ resources:
           HostedZoneId: Z2FDTNDATAQYW2
           EvaluateTargetHealth: false
         Type: A
+    HstsCloudfrontFunction:
+      Type: AWS::CloudFront::Function
+      Properties:
+        AutoPublish: true
+        FunctionCode: |
+          function handler(event) {
+            var response = event.response;
+            var headers = response.headers;
+            headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
+            return response;
+          }
+        FunctionConfig:
+          Comment: This function adds headers to implement HSTS
+          Runtime: cloudfront-js-1.0
+        Name: hsts-${self:custom.stage}
     ###############This code block enables logging on waf and sends all logs to s3.##################################
     Firehose:
       Type: AWS::KinesisFirehose::DeliveryStream


### PR DESCRIPTION
## Purpose

This implements HTTP Strict Transport Security on our applications frontend Cloudfront Distribution and meets a compliance requirement

#### Linked Issues to Close

Closes #244

## Approach

This issue was to implement HTTP Strict Transport Security for our web application.  Our frontend is a static React website hosted in S3 and fronted by Cloudfront, so this issue called for a mechanism for adding Headers to a Cloudfront response. 
 Modifying Cloudfront headers is possible using [CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html).  This is a new component of Cloudfront, and our header manipulation case is a perfect candidate for it.

This changeset adds a javascript function that takes a Cloudfront response and adds the "strict-transport-security" header.  This function is tied to the "viewer-reponse" event, one of the four possible events for Cloudfront functions (see [docs](https://aws.amazon.com/blogs/aws/introducing-cloudfront-functions-run-your-code-at-the-edge-with-low-latency-at-any-scale/).  So each response from Cloudfront gets this header added before it reaches the end user, and we meet our compliance requirement.

Please refer to the docs linked in this PR for more details.  But, in summary, CloudFront functions:
- run in less than one millisecond.
- scale to millions of requests per second instantly.
- free tier of 2 million requests per month
- charged $.10 per million requests after free tier
- falls under Cloudfront, so no new service to approve

## Learning

Guides used:
- [AWS guide for Cloudfront Functions](https://aws.amazon.com/blogs/aws/introducing-cloudfront-functions-run-your-code-at-the-edge-with-low-latency-at-any-scale/)
- [Cloudformation docs for AWS::CloudFront::Function](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-function.html)
- [Cloudformation docs for AWS::CloudFront::Distribution LambdaFunctionAssociation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-lambdafunctionassociation.html)
- [Pricing and general info](https://aws.amazon.com/cloudfront/pricing/)

## Assorted Notes/Considerations

It's worth noting that this functionality is also able to be implemented using Lambda@Edge, instead of Cloudfront functions, and was developed for this project but never merged.  See [Lambda@Edge PR](https://github.com/CMSgov/macpro-quickstart-serverless/pull/244).  However, for this use case, Cloudfront Functions is orders of magnitude faster, much cheaper, and much less code.  

I don't know the GitHub handle so I can't tag... but big shoutout to our AWS TAM Piotr.  I explained this issue and asked a question about Lambda@Edge, and he pointed us to the new Cloudfront Functions offering.  

Screenshots:
_response headers from the current master environment, without hsts_
<img width="1286" alt="Screen Shot 2021-05-27 at 11 20 07 AM" src="https://user-images.githubusercontent.com/48921055/119976450-1b080c80-bf85-11eb-805f-1943b191d13e.png">

_response headers from this branch's environment, with the hsts header added_
<img width="1439" alt="Screen Shot 2021-05-27 at 11 20 54 AM" src="https://user-images.githubusercontent.com/48921055/119976494-2824fb80-bf85-11eb-93d2-384ba9b9e6d7.png">

This pattern of header manipulation via Cloudfront Functions can be followed to add other HTTP security headers.  In fact, there's a conveniently published [http security header example](https://github.com/aws-samples/amazon-cloudfront-functions/blob/main/add-security-headers/index.js) to reference, already written in javascript.  Simply add to the existing CloudFront function code at will.  This PR was deliberately scoped to just the HSTS header to make it more broadly applicable, as headers such as Content Security Policy might be application specific.  It's suggested that a new issue be made for broader HTTP Security headers, and prioritized as appropriate.  


#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
