### PR TITLE
Fix and significantly speed up the destroy script

### DIFF
--- a/destroy.sh
+++ b/destroy.sh
@@ -7,8 +7,7 @@ if [[ $1 == "" ]] ; then
 fi
 stage=$1
 
-# A list of names commonly used for protected/important branches/environments/stages.
-# Update as appropriate.
+# A list of protected/important branches/environments/stages.
 protected_stage_regex="(^master$|^val$|^production)"
 if [[ $stage =~ $protected_stage_regex ]] ; then
     echo """
@@ -29,25 +28,25 @@ if [[ $stage =~ $protected_stage_regex ]] ; then
 fi
 echo "\nCollecting information on stage $stage before attempting a destroy... This can take a minute or two..."
 
-# Find buckets associated with stage
-# Unfortunately, I can't get all buckets and all associaged tags in a single CLI call (that I know of)
-# So this can be pretty slow, depending on how many buckets exist in the account
-# We get all bucket names, then find associated tags for each one-by-one
-bucketList=(`aws s3api list-buckets --output text --query 'Buckets[*].Name'` )
-filteredBucketList=()
-set +e
-for i in "${bucketList[@]}"
-do
-  stage_tag=`aws s3api get-bucket-tagging --bucket $i --output text --query 'TagSet[?Key==\`STAGE\`].Value' 2>/dev/null`
-  if [ "$stage_tag" == "$stage" ]; then
-    filteredBucketList+=($i)
-  fi
-done
 set -e
 
 # Find cloudformation stacks associated with stage
-filteredStackList=(`aws cloudformation describe-stacks | jq -r ".Stacks[] | select(.Tags[] | select(.Key==\"STAGE\") | select(.Value==\"$stage\")) | .StackName"`)
+stackList=(`aws cloudformation describe-stacks | jq -r ".Stacks[] | select(.Tags[] | select(.Key==\"STAGE\") | select(.Value==\"$stage\")) | .StackName"`)
 
+# Find buckets attached to any of the stages, so we can empty them before removal.
+bucketList=()
+set +e
+for i in "${stackList[@]}"
+do
+  buckets=(`aws cloudformation list-stack-resources --stack-name $i | jq -r ".StackResourceSummaries[] | select(.ResourceType==\"AWS::S3::Bucket\") | .PhysicalResourceId"`)
+  for j in "${buckets[@]}"
+  do
+    # Sometimes a bucket has been deleted outside of CloudFormation; here we check that it exists.
+    if aws s3api head-bucket --bucket $j > /dev/null 2>&1; then
+      bucketList+=($j)
+    fi
+  done
+done
 
 echo """
 ********************************************************************************
@@ -56,10 +55,10 @@ echo """
 """
 
 echo "The following buckets will be emptied"
-printf '%s\n' "${filteredBucketList[@]}"
+printf '%s\n' "${bucketList[@]}"
 
-echo "\nThe following stacks will be destroyed:"
-printf '%s\n' "${filteredStackList[@]}"
+echo "The following stacks will be destroyed:"
+printf '%s\n' "${stackList[@]}"
 
 echo """
 ********************************************************************************
@@ -76,14 +75,42 @@ if [ "$CI" != "true" ]; then
   fi
 fi
 
-for i in "${filteredBucketList[@]}"
+for i in "${bucketList[@]}"
 do
   echo $i
+  set -e
+
+  # Suspend bucket versioning.
+  aws s3api put-bucket-versioning --bucket $i --versioning-configuration Status=Suspended
+
+  # Remove all bucket versions.
+  versions=`aws s3api list-object-versions \
+    --bucket "$i" \
+    --output=json \
+    --query='{Objects: Versions[].{Key:Key,VersionId:VersionId}}'`
+  if ! echo $versions | grep -q '"Objects": null'; then
+    aws s3api delete-objects \
+      --bucket $i \
+      --delete "$versions" > /dev/null 2>&1
+  fi
+
+  # Remove all bucket delete markers.
+  markers=`aws s3api list-object-versions \
+    --bucket "$i" \
+    --output=json \
+    --query='{Objects: DeleteMarkers[].{Key:Key,VersionId:VersionId} }'`
+  if ! echo $markers | grep -q '"Objects": null'; then
+    aws s3api delete-objects \
+      --bucket $i \
+      --delete "$markers" > /dev/null 2>&1
+  fi
+
+  # Empty the bucket
   aws s3 rm s3://$i/ --recursive
 done
 
-
-for i in "${filteredStackList[@]}"
+# Trigger a delete for each cloudformation stack
+for i in "${stackList[@]}"
 do
   echo $i
   aws cloudformation delete-stack --stack-name $i


### PR DESCRIPTION
## Purpose

This changeset fixes a bug (introduced by bucket versioning #274) with the destroy script, and speeds things up signifcantly.

#### Linked Issues to Close

Closes #141 
Bug Fix against / related to:  #274 

## Approach

As stated in the linked issue, bucket versioning broke the destroy functionality.  
These changes modify how buckets are emptied prior to cloudformation stacks being removed.  Now, the script removes all object versions and delete markers, a requirement to delete the bucket.

While working on this, I changed the way this script discovered buckets.  Previously, the script found all buckets, then looked for those with a STAGE tag that matched the target stage.  Tags can only be found by making calls for an individual bucket, which meant the script took a long time to run.  Now, the script iterates over the target cloudformation stages and searches for any AWS::S3::Bucket resources.  This is a simpler and much faster operation.

## Learning

N/A

## Assorted Notes/Considerations

This is a bug against the bucket versioning PR.  As such, I'm adding the 'Compliance' label to this PR, so it will surface in searches for the compliance related versioning PR.

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
