### PR TITLE
Update Cloudfront domain name reference

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -247,7 +247,7 @@ resources:
         Value:
           Fn::If:
             - CreateCustomCloudFrontDomain
-            - https://${env:CLOUDFRONT_DOMAIN_NAME, ""}/
+            - https://${self:custom.cloudfrontDomainName, ""}/
             - Fn::Join:
                 - ""
                 - - https://


### PR DESCRIPTION
There is a line trying to find the cloudfront domain name through an environment file we are phasing out. And defaults to a blank string thus overwriting the parameter if nothing is found.


#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
