### PR TITLE
Remediate S3.8 Security Hub Finding - upgrade serverless-s3-bucket-helper to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "serverless-online": "CMSgov/serverless-online",
     "serverless-plugin-scripts": "^1.0.2",
     "serverless-plugin-warmup": "^5.3.1",
-    "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper",
+    "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper#0.1.0",
     "serverless-stack-termination-protection": "^1.0.4",
     "typescript": "^4.0.5",
     "yargs": "^16.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9411,9 +9411,9 @@ serverless-plugin-warmup@^5.3.1:
   resolved "https://registry.yarnpkg.com/serverless-plugin-warmup/-/serverless-plugin-warmup-5.3.1.tgz#cc8ca43452c5468a79a7b5447c84267035fa8d1e"
   integrity sha512-+nY6VCTLf/VjwkwAudtCXE/neaYSKy+9NmnYTSL0y8ZGfKB6u9Hrh9J2vqYEcam6eQFnCAEsch9iTs/dbU2vGg==
 
-serverless-s3-bucket-helper@CMSgov/serverless-s3-bucket-helper:
+serverless-s3-bucket-helper@CMSgov/serverless-s3-bucket-helper#0.1.0:
   version "1.0.0"
-  resolved "https://codeload.github.com/CMSgov/serverless-s3-bucket-helper/tar.gz/6316e139c4c4742c44911aaaf71585ea69f92c17"
+  resolved "https://codeload.github.com/CMSgov/serverless-s3-bucket-helper/tar.gz/a6016a9ab164a21044741eb8eb69293f729605a0"
 
 serverless-stack-termination-protection@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Purpose

This changeset updates the version of [serverless-s3-bucket-helper](https://github.com/cmsgov/serverless-s3-bucket-helper) in use to 0.1.0.  Using the 0.1.0 release of [serverless-s3-bucket-helper](https://github.com/cmsgov/serverless-s3-bucket-helper) (see upstream PR/Issue https://github.com/CMSgov/serverless-s3-bucket-helper/pull/4) will remediate this project's S3.8 findings in Security Hub.

#### Linked Issues to Close

Closes #309 

## Approach

The changes in serverless-s3-bucket-helper's 0.1.0 release were specifically designed to meet S3.8 requirements.  Please see the upstream's PR/Issue for details.  

In short, all buckets will have 'block public access' settings set to true by default.  So, by using the new version of this plugin, all buckets made by the application or its underlying deployment tooling will be S3.8 compliant.

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
