### PR TITLE
Integrate Security Hub - Fix

### DIFF
--- a/.github/workflows/deploy-support.yml
+++ b/.github/workflows/deploy-support.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       # # List of all branches which should control underlying infrastructure.
-      # - master
-      - sechub
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
## Purpose

PR #319 was merged with a development value in its codebase.  This value specifies for which branch/branches the github workflow should run, which is difficult to lock to master when working on a dev branch.  So I had pushed a change to tell the new workflow to run for my development branch, sechub, when it should be set to run on master.  This undoes that dev change.

I'm going to skip the rest of the standard PR template.  
