### PR TITLE
Bug Fix - Add Workflow Status filters to sechub's sync function

### DIFF
--- a/services/.sechub/handlers/sync.js
+++ b/services/.sechub/handlers/sync.js
@@ -59,6 +59,16 @@ async function getAllActiveFindings() {
                 Value: "ACTIVE",
               },
             ],
+            WorkflowStatus: [
+              {
+                Comparison: "EQUALS",
+                Value: "NEW",
+              },
+              {
+                Comparison: "EQUALS",
+                Value: "NOTIFIED",
+              },
+            ],
             SeverityLabel: severityLabels,
           },
           MaxResults: 100,


### PR DESCRIPTION
## Purpose

This changeset fixes #325; it adds Workflow Status filters to the sechub service's sync function, to match the filtering behavior of Security Hub's default view.

#### Linked Issues to Close

Closes #325 

## Approach

Without this changeset, we match all Record State = ACTIVE findings.  But findings can be ACTIVE, as in valid, but have a Workflow Status value of SUPPRESSED or RESOLVED.  

We want to ignore SUPPRESSED or RESOLVED active findings.  This change adds filters to only select records with workflow status values of NEW or NOTIFIED (the other two possible statuses).  The net result is a set of filters that match the Security Hub's default view in the console, which makes sense.

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
