### PR TITLE
Consider paginated reply from octokit's listCards method

### DIFF
--- a/services/.sechub/handlers/sync.js
+++ b/services/.sechub/handlers/sync.js
@@ -232,6 +232,20 @@ async function createOrUpdateIssuesBasedOnFindings(findings, issues) {
   }
 }
 
+async function getAllCardsForColumn(columnId) {
+  let cards = [];
+  for await (const response of octokit.paginate.iterator(
+    octokit.rest.projects.listCards,
+    {
+      ...octokitRepoParams,
+      column_id: columnId,
+    }
+  )) {
+    cards.push(...response.data);
+  }
+  return cards;
+}
+
 async function assignIssuesToProject(issues, projectId, defaultColumnName) {
   console.log(
     `******** Project ${projectId}:  Ensuring all GitHub Issues are attached to the Project ********`
@@ -257,11 +271,7 @@ async function assignIssuesToProject(issues, projectId, defaultColumnName) {
   // Iterate over the Project's columns, and put all cards into a single array.
   var projectCards = [];
   for (let i = 0; i < targetColumnIds.length; i++) {
-    let cards = (
-      await octokit.rest.projects.listCards({
-        column_id: targetColumnIds[i],
-      })
-    ).data;
+    let cards = await getAllCardsForColumn(targetColumnIds[i]);
     projectCards.push(...cards);
   }
 


### PR DESCRIPTION
## Purpose

This changeset fixes a bug with the sechub sync function, where adding issues to large project boards would not work as intended.

#### Linked Issues to Close

Closes #333 

## Approach

As described in the issue, the current (before this changeset) sync function code did not consider getting a paginated reply from octokit's listCards method.  

The approach here is to add a helper method which will step through all pages, if more than one, in the reply. 

## Learning

N/A

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
