### PR TITLE
Fix sechub bug around filtering issues by account

### DIFF
--- a/services/.sechub/handlers/sync.js
+++ b/services/.sechub/handlers/sync.js
@@ -91,7 +91,7 @@ async function getAllIssues() {
     {
       ...octokitRepoParams,
       state: "all",
-      labels: ["security-hub"],
+      labels: ["security-hub", stage],
     }
   )) {
     issues.push(...response.data);
@@ -103,7 +103,7 @@ function issueParamsForFinding(finding) {
   return {
     title: `SHF - ${repo} - ${stage} - ${finding.Severity.Label} - ${finding.Title}`,
     state: "open",
-    labels: ["security-hub"],
+    labels: ["security-hub", stage],
     body: `**************************************************************
 __This issue was generated from Security Hub data and is managed through automation.__
 Please do not edit the title or body of this issue, or remove the security-hub tag.  All other edits/comments are welcome.


### PR DESCRIPTION
## Purpose

This changeset fixes a bug that affected consumers of the sechub service who deployed to multliple accounts

#### Linked Issues to Close

Closes #464 

## Approach

The approach matches the proposed solution in the issue:
- A 'stage' label is attached to all github issues created by the sync function
- the getAllIssues function is updated to fetch all issues labeled 'security-hub' and '<stagename>'

With the above change, the 'close issues with no active finding' logic is fixed... the sync function will only manage github issues built by security hub for that stage/aws-account

## Learning

I really wish the quickstart had multiple accounts.  This bug could have been anticipated, but we failed.  Multiple accounts are what surfaced it; wish that happened sooner.

## Assorted Notes/Considerations


#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
