### PR TITLE
Enabling cloudfront logs

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -88,6 +88,32 @@ resources:
               Principal:
                 CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
         Bucket: !Ref S3Bucket
+    LoggingBucket:
+      Type: "AWS::S3::Bucket"
+      Properties:
+        BucketName: !Sub ${self:custom.stage}-cloufront-logging
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: "AES256"
+      DeletionPolicy: Delete
+    LoggingBucketPolicy:
+      Type: "AWS::S3::BucketPolicy"
+      Properties:
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: "s3:PutObject"
+              Resource: !Sub arn:aws:s3:::${LoggingBucket}/*
+              Principal:
+                AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+        Bucket: !Ref LoggingBucket
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL
       Properties:
@@ -166,6 +192,8 @@ resources:
               ResponseCode: 403
               ResponsePagePath: /index.html
           WebACLId: !GetAtt CloudFrontWebAcl.Arn
+          Logging:
+            Bucket: !Sub "${LoggingBucket}.s3.amazonaws.com"
     Route53DnsRecord:
       Type: AWS::Route53::RecordSet
       Condition: CreateDnsRecord

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -91,7 +91,7 @@ resources:
     LoggingBucket:
       Type: "AWS::S3::Bucket"
       Properties:
-        BucketName: !Sub ${self:service}-${self:custom.stage}-cloudfront-logs
+        BucketName: !Sub ${self:service}-${self:custom.stage}-cloudfront-logs-${AWS::AccountId}
         PublicAccessBlockConfiguration:
           BlockPublicAcls: true
           BlockPublicPolicy: true

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -91,7 +91,7 @@ resources:
     LoggingBucket:
       Type: "AWS::S3::Bucket"
       Properties:
-        BucketName: !Sub ${self:custom.stage}-cloufront-logging
+        BucketName: !Sub ${self:service}-${self:custom.stage}-cloudfront-logs
         PublicAccessBlockConfiguration:
           BlockPublicAcls: true
           BlockPublicPolicy: true
@@ -194,6 +194,7 @@ resources:
           WebACLId: !GetAtt CloudFrontWebAcl.Arn
           Logging:
             Bucket: !Sub "${LoggingBucket}.s3.amazonaws.com"
+            Prefix: AWSLogs/CLOUDFRONT/${self:custom.stage}/
     Route53DnsRecord:
       Type: AWS::Route53::RecordSet
       Condition: CreateDnsRecord


### PR DESCRIPTION
## Purpose
Enabling logging on clodfront distribution to write the logs to an s3 bucket
_Describe the problem or feature in addition to a link to the issues._

#### Linked Issues to Close

Closes #487 
## Approach
The approach is to create an s3 bucket to host the cloudfront logs and then enable logging on the cloudfront distribution in the quickstart repo to write the logs to the s3 bucket

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
