### PR TITLE
Disallows user self sign up to cognito user pool

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -99,6 +99,8 @@ resources:
             AttributeDataType: String
             Mutable: true
             Required: false
+        AdminCreateUserConfig:
+          AllowAdminCreateUserOnly: True # This setting disables self sign-up for users
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
       Properties:


### PR DESCRIPTION
## Purpose

Resolve issues from 3/16/2022 pen test allowing open user creation

#### Linked Issues to Close

[https://qmacbis.atlassian.net/browse/OY2-17149) ](https://qmacbis.atlassian.net/browse/OY2-17149)

## Approach

Removes ability for user to sign themself up.

## Assorted Notes/Considerations

Only applicable if desired behavior is to disallow user self signup

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
