### PR TITLE
Add Cypress to node cache to avoid failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,8 +46,10 @@ jobs:
           node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
       - uses: actions/cache@v2
         with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
+          path: |
+            "**/node_modules"
+            "~/.cache/Cypress"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-2
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
@@ -111,8 +113,10 @@ jobs:
           node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
       - uses: actions/cache@v2
         with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
+          path: |
+            "**/node_modules"
+            "~/.cache/Cypress"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-2
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
@@ -167,8 +171,10 @@ jobs:
           node-version: ${{ steps.node_version.outputs.NODE_VERSION }}
       - uses: actions/cache@v2
         with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}
+          path: |
+            "**/node_modules"
+            "~/.cache/Cypress"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-2
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,9 +47,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            "**/node_modules"
-            "~/.cache/Cypress"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-2
+            **/node_modules
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-3
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
@@ -114,9 +114,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            "**/node_modules"
-            "~/.cache/Cypress"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-2
+            **/node_modules
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-3
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
@@ -172,9 +172,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            "**/node_modules"
-            "~/.cache/Cypress"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-2
+            **/node_modules
+            ~/.cache/Cypress
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock', 'plugins/**') }}-3
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
## Purpose

This changeset is a fix related to https://github.com/CMSgov/macpro-quickstart-serverless/pull/530
The github action for cypress has some caching behavior that wasn't fully undertstood and was causing failure some of the time.

#### Linked Issues to Close

Related to https://github.com/CMSgov/macpro-quickstart-serverless/pull/530

## Approach

The Cypress github action handles installation of Cypress, sometimes.  If it detects you're using github cachine, which we were, it will not install Cypress.  It expects Cypress to be at ~/.cache/Cypress.  So if you're using caching, but not caching ~/.cache/Cypress, you'll fail.

There were two options:
- Override the "you have a cache so i wont install" behavior and force the action to install Cypress, by specifying install:true in the action.  
- Start caching ~/.cache/Cypress

We went with the latter, ultimately because caching ensures the tests will use the exact version of Cypress specified in yarn.lock.  While caching ~/.cache/Cypress does bloat the cache significantly, we valued version fidelity more than performance.  

## Learning

The cypress github action tries to be smart by detecting caching, but it's not smart enough to install Cypress if it's there or not.

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
