### PR TITLE
Modify branch name setting to account for the dependabot switch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,12 @@ jobs:
         containers: [test.spec.js, test2.spec.js]
     steps:
       - name: set branch_name
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
+          else
+            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v1
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names
@@ -152,7 +157,12 @@ jobs:
         containers: [homePage]
     steps:
       - name: set branch_name
-        run: echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/heads/dependabot/.* ]]; then # Dependabot builds very long branch names.  This is a switch to make it shorter.
+            echo "branch_name=`echo ${GITHUB_REF#refs/heads/} | md5sum | head -c 10 | sed 's/^/x/'`" >> $GITHUB_ENV
+          else
+            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v1
       - name: set branch specific variable names
         run: ./.github/build_vars.sh set_names


### PR DESCRIPTION
## Purpose

This fixes an issue related to https://github.com/CMSgov/macpro-quickstart-serverless/pull/530
In the test jobs, the 'set branch name' step did not account for dependabot branches, as seen in the deploy job

#### Linked Issues to Close

N/A, but related to https://github.com/CMSgov/macpro-quickstart-serverless/pull/530

## Approach

The deploy job has a switch that makes dependabot branch names usable.  The test jobs did not have that switch correctly copied/pasted.  This simply updates the 'set branch name' steps to match.

## Learning

We noticed this when dependabot branches had their tests failing.  It was tough to discover earlier.

## Assorted Notes/Considerations

N/A

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
