### PR TITLE
enable PKCE OAuth2 code flow extension with federatedSignIn()

### DIFF
--- a/services/ui-src/src/App.js
+++ b/services/ui-src/src/App.js
@@ -55,11 +55,7 @@ function App() {
         loginLocalUser(alice);
         userHasAuthenticated(true);
       } else {
-        const authConfig = Auth.configure();
-        const { domain, redirectSignIn, responseType } = authConfig.oauth;
-        const clientId = authConfig.userPoolWebClientId;
-        const url = `https://${domain}/oauth2/authorize?redirect_uri=${redirectSignIn}&response_type=${responseType}&client_id=${clientId}`;
-        window.location.assign(url);
+        Auth.federatedSignIn();
       }
     } catch (e) {
       onError(e);

--- a/services/ui-src/src/index.js
+++ b/services/ui-src/src/index.js
@@ -19,7 +19,7 @@ Amplify.configure({
       domain: config.cognito.APP_CLIENT_DOMAIN,
       redirectSignIn: config.cognito.REDIRECT_SIGNIN,
       redirectSignOut: config.cognito.REDIRECT_SIGNOUT,
-      scope: ["email", "openid"],
+      scope: ["email", "openid", "aws.cognito.signin.user.admin"],
       responseType: "code",
     },
   },


### PR DESCRIPTION
This method uses 'Cognito' as the Identity Provider.

## Purpose

The purpose is to implement best practices for OAuth2 authorization_code grant flow.
Amplify Auth federatedSignIn() implements PKCE, the extension for OAuth2 authorization_code grant flow.

## Learning
See [this page](https://confluenceent.cms.gov/display/CMCSMAC/Quickstart%3A+Improvements#Quickstart:Improvements-UseAmplifyAuthfederatedSignInforaddedloginsecurity(medium)) for my motivation for this change.

See this [ietf informational doc](https://tools.ietf.org/html/rfc7636) that describes best practices for Single-Page Apps.

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
