### PR TITLE
change ACM TLS policy to TLSv1.2

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -184,7 +184,7 @@ resources:
             Fn::If:
               - CreateCustomCloudFrontDomain
               - AcmCertificateArn: ${self:custom.cloudfrontCertificateArn}
-                MinimumProtocolVersion: TLSv1
+                MinimumProtocolVersion: TLSv1.2_2021
                 SslSupportMethod: sni-only
               - CloudFrontDefaultCertificate: true
           CustomErrorResponses:


### PR DESCRIPTION
## Purpose

When `CreateCustomCloudFrontDomain` is true, QuickStart deploys an ACM certificate on the CloudFront distribution. This PR changes the `MinimumProtocolVersion` from TLSv1 to the latest policy: `TLSv1.2_2021`. This policy is described [here](https://aws.amazon.com/about-aws/whats-new/2021/06/amazon-cloudfront-announces-new-tlsv12_2021-security-policy-for-viewer-connections/).


#### Linked Issues to Close
https://jiraent.cms.gov/browse/CMCSMACD-559


#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
