### PR TITLE
Bharvey sessions

### DIFF
--- a/services/ui-auth/README.md
+++ b/services/ui-auth/README.md
@@ -25,6 +25,22 @@ The reference docs for AWS resources referenced in `serverless.yml` are:
 - [IAM](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_IAM.html)
 - [functions](https://www.serverless.com/framework/docs/providers/aws/guide/functions)
 
+## Session Management
+
+For the Cognito IdP, absolute session timeout is implemented by limiting the lifetime of the refresh token that is issued by Cognito when a user signs in. If this token has expired, upon the next user action that requires an access token, the Amplify framework will make a refresh request, detect the expired refresh token, and redirect the user back to the login page. The default value for session timeout is set to 4 hours, and customized in `serverless.yml`:
+
+```yml
+resources:
+  ...
+  Resources:
+  ...
+  CognitoUserPoolClient:
+    ...
+      RefreshTokenValidity: 4
+      TokenValidityUnits:
+        RefreshToken: hours
+```
+
 ## Service-Specific Configuration Parameters
 
 To enable Cognito to send email using AWS SES, you must move your AWS account out of the AWS SES sandbox. Instructions on how to do that are [here](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html).

--- a/services/ui-auth/README.md
+++ b/services/ui-auth/README.md
@@ -27,7 +27,7 @@ The reference docs for AWS resources referenced in `serverless.yml` are:
 
 ## Session Management
 
-For the Cognito IdP, absolute session timeout is implemented by limiting the lifetime of the refresh token that is issued by Cognito when a user signs in. If this token has expired, upon the next user action that requires an access token, the Amplify framework will make a refresh request, detect the expired refresh token, and redirect the user back to the login page. The default value for session timeout is set to 4 hours, and customized in `serverless.yml`:
+For the Cognito IdP, absolute session timeout is implemented by limiting the lifetime of the refresh token that is issued by Cognito when a user signs in. If this token has expired, upon the next user action that requires an access token, the Amplify framework will make a refresh request, detect the expired refresh token, and redirect the user back to the login page. The value for session timeout can be customized in `serverless.yml`:
 
 ```yml
 resources:

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -146,7 +146,7 @@ resources:
               - BackWithOkta
               - !Ref OktaUserPoolIdentityProvider
               - !Ref AWS::NoValue
-        RefreshTokenValidity: 1
+        RefreshTokenValidity: 4
         TokenValidityUnits:
           RefreshToken: hours
     UserPoolDomain:

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -146,6 +146,9 @@ resources:
               - BackWithOkta
               - !Ref OktaUserPoolIdentityProvider
               - !Ref AWS::NoValue
+        RefreshTokenValidity: 1
+        TokenValidityUnits:
+          RefreshToken: hours
     UserPoolDomain:
       Type: AWS::Cognito::UserPoolDomain
       Properties:


### PR DESCRIPTION
## Purpose

This change sets an absolute session timeout for the Cognito IdP by changing the value of the refresh token expiration, and adds a section to the README explaining how to customize this value.

#### Linked Issues to Close

N/A

## Approach

When a user signs in, Cognito sends Amplify back a refresh token along with an access token and ID token. When it detects an expired acccess token, Amplify makes calls to renew the session by using the refresh token to fetch another access token.  The default expiration of the access token is 60 minutes, and for the refresh token it's 30 days.

Best practice for session management to have an absolute session timeout.  This minimizes the time period an attacker can launch session-based attacks.  [OWASP recommends a range of 4-8 hours for absolute session timeout](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#session-expiration
), which balances usability with security.  The only built-in mechanism Cognito gives for controlling session length is by adjusting the expiration of the refresh token.  When this token expires, Amplify detects the expired refresh token on the next user action that requires an access token, and the user is logged out and redirected to the login page.  Logging in starts a new session with a new refresh token. 

Cognito doesn't support rotating refresh tokens (where a new refresh token is sent, and the old one invalidated, with every request to exchange a refresh token for an access token).  Rather, the same refresh token is used for each refresh request.  Given this, it makes sense to limit the lifetime of that token to mitigate the damage that could be caused by theft of the token. 

Cognito does support invalidation of refresh tokens via an [API endpoint](https://docs.aws.amazon.com/cognito/latest/developerguide/revocation-endpoint.html).  Amplify [revokes tokens](https://docs.amplify.aws/lib/auth/emailpassword/q/platform/js/#sign-out) when you call `signOut` or `globalSignOut`.  So you could theoretically impose a session on the client side by setting a timer and using one of these methods.   Reducing the lifetime of the refresh token seems simpler and doesn't add any new client code. 

## Learning

Lots of reading [AWS Cognito](https://docs.aws.amazon.com/cognito/index.html) and [Amplify](https://docs.amplify.aws/) docs

## Assorted Notes/Considerations

Testing:
I changed the refresh token expiration, started a session, let the session time out,  and via the Chrome inspector watched the refresh request fail and trigger a redirect to the login page

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
