### PR TITLE
upgrade codeql to avoid deprecation

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,9 +29,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## Purpose

While implementing the changes from the [codeQL PR](https://github.com/CMSgov/macpro-quickstart-serverless/pull/239) I noticed in a recent run that codeQL is set to deprecate v1 soon. I ran mine with v2 and it worked as expected. The [CodeQL docs also use v2](https://github.com/github/codeql-action) in their README. Just passing this up so you don't hit the deprecation!

<img width="1027" alt="Screen Shot 2022-08-05 at 11 20 46 AM" src="https://user-images.githubusercontent.com/57802560/183137981-618a715c-95d9-43f3-84dd-ae8436ca2bd2.png">

More [notes on the deprecation here](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/). I believe we aren't using a GitHub Enterprise Server, in which case we should be ok to upgrade.

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
