### PR TITLE
Check for IAM Role Name Length

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,19 +3,37 @@
 # input: a stage name (note that this script appends "-dev" to the provided stage name)
 #
 # iterates through the list of services defined in this script and:
-# - installs dependencies
-# - deploys the service to the provided stage
+# - verifies the IamRoleLambdaExecution.RoleName is less than 65 characters
+# - RoleName is composed like this:
+#   {service}-{stage}-{function}-{region}-lambdaRole per https://github.com/functionalone/serverless-iam-roles-per-function#role-names
+#   Assumptions about RoleName:
+#   region is 9 characters (us-east-1)
+#   MAXLENGTH = 64 - {region}
+#   restrict the length of {service} + {stage} + {function} <= MAXLENGTH
+#
+#
+# after service+stage+function names have been validated:
+#   iterates through the list of services defined in this script and:
+#   - installs dependencies
+#   - deploys the service to the provided stage
 #
 # finally, outputs the CloudFront URL of the deployed application
 
 set -e
 
-if [[ $1 == "" ]] ; then
+if [[ $1 == "" ]]; then
     echo 'ERROR:  You must pass a stage to deploy.  Ex. sh deploy.sh my-stage-name'
     exit 1
 fi
 
 stage=${1:-dev}
+valid_stage="^[a-z][a-z0-9-]*$"
+MAXLENGTH=55
+
+if [[ ! $1 =~ $valid_stage ]]; then
+    echo "ERROR: stage name is not a valid name. It must match the pattern ${valid_stage}"
+    exit 1
+fi;
 
 services=(
   'database'
@@ -27,6 +45,39 @@ services=(
   'ui-auth'
   'ui-src'
 )
+
+getMaxFuncName() {
+  longestFuncName=""
+  maxFuncLen=0
+  for file in *
+  do
+    funcName=$(echo "$file" | cut -d '.' -f1)
+    if [[ ${#funcName} -gt ${maxFuncLen} ]]; then
+      maxFuncLen=${#funcName}
+      longestFuncName=${funcName}
+    fi
+  done
+  echo "${longestFuncName}"
+}
+
+checkStageServiceFunctionLength() {
+  for i in "${services[@]}"
+  do
+    if find "./services/${i}" -maxdepth 1 -type d | grep -q handlers; then
+      funcName=$(cd "./services/${i}/handlers"; getMaxFuncName)
+    fi
+    if [[ $((${#stage} + ${#i} + ${#funcName})) -gt ${MAXLENGTH} ]]; then
+      if [[ ${#funcName} -gt 0 ]]
+      then
+        echo "ERROR: length of stage ${stage} (${#stage}) + service ${i} (${#i}) + function ${funcName} (${#funcName}) exceeds ${MAXLENGTH} characters"
+        exit 1
+      else
+        echo "ERROR: length of stage ${stage} (${#stage}) + service ${i} (${#i}) exceeds ${MAXLENGTH} characters"
+        exit 1
+      fi
+    fi
+  done
+}
 
 install_deps() {
   if [ "$CI" == "true" ]; then # If we're in a CI system
@@ -46,6 +97,8 @@ deploy() {
   popd
 }
 
+checkStageServiceFunctionLength
+
 install_deps
 export PATH=$(pwd)/node_modules/.bin/:$PATH
 
@@ -56,6 +109,7 @@ done
 
 pushd services
 echo """
+
 ------------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------
 Application endpoint:  `./output.sh ui CloudFrontEndpointUrl $stage`

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -91,9 +91,9 @@ install_deps() {
 
 deploy() {
   service=$1
-  pushd services/$service
+  pushd services/"$service"
   install_deps
-  serverless deploy  --stage $stage
+  serverless deploy  --stage "$stage"
   popd
 }
 
@@ -104,7 +104,7 @@ export PATH=$(pwd)/node_modules/.bin/:$PATH
 
 for i in "${services[@]}"
 do
-	deploy $i
+	deploy "$i"
 done
 
 pushd services
@@ -112,7 +112,7 @@ echo """
 
 ------------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------------
-Application endpoint:  `./output.sh ui CloudFrontEndpointUrl $stage`
+Application endpoint:  $(./output.sh ui CloudFrontEndpointUrl "$stage")
 ------------------------------------------------------------------------------------------------
 """
 popd


### PR DESCRIPTION
## Purpose
To check the length of the AWS `IamRoleLambdaExecution.RoleName` for every lambda before the QuickStart is deployed.
# Background
serverless.com creates a IAM RoleName with various fields:
{service}-{stage}-{function}-{region}-lambdaRole per [serverless-iam-roles-per-function plugin](https://github.com/functionalone/serverless-iam-roles-per-function#role-names)
In this PR, I  assume:
#   {region} is 9 characters (i.e., `us-east-1`)
#   MAXLENGTH = 64 - {region}
#   restrict the length of {service} + {stage} + {function} <= MAXLENGTH

#### Linked Issues to Close
(https://jiraent.cms.gov/browse/CMCSMACD-528)

## Learning

I learned that serverless.com constructs the default Iam RoleName using {service}-{stage}-{region}-lambaRole
The plugin listed above adds an additional field: `-{function}-`
This can easily cause the deploy to fail for some combination of stage, service, function.
This is especially frustrating when the failure happens towards the end of the deploy.

## Assorted Notes/Considerations
Notes are linked in the jira ticket, which is linked above.

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
