### PR TITLE
Use `serverless-offline-ssm` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ When run locally, auth bypasses Cognito. The frontend mimics login using local s
 
 #### Pre-Requisites
 
-- valid short-term access keys for your AWS account pasted in your terminal window
-
 Run _all_ the services locally with the command `./scripts/dev.sh local`. For example,
 
 ```

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "serverless-iam-helper": "CMSgov/serverless-iam-helper",
     "serverless-idempotency-helper": "CMSgov/serverless-idempotency-helper",
     "serverless-offline": "^8.5.0",
+    "serverless-offline-ssm": "^6.2.0",
     "serverless-online": "CMSgov/serverless-online",
     "serverless-plugin-scripts": "^1.0.2",
     "serverless-plugin-warmup": "^7.1.0",

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -11,6 +11,7 @@ plugins:
   - serverless-dotenv-plugin
   - serverless-plugin-warmup
   - serverless-associate-waf
+  - serverless-offline-ssm
   - serverless-offline
   - serverless-stack-termination-protection
   - serverless-idempotency-helper
@@ -48,6 +49,14 @@ custom:
       concurrency: ${ssm:/configuration/${self:custom.stage}/warmup/concurrency, ssm:/configuration/default/warmup/concurrency, 5}
   serverless-iam-roles-per-function:
     defaultInherit: true
+  serverless-offline-ssm:
+    stages:
+      - local
+  ssm:
+    "/configuration/local/iam/path": "/"
+    "/configuration/local/iam/permissionsBoundaryPolicy": ""
+    "/configuration/${self:custom.stage}/warmup/schedule": "4 minutes"
+    "/configuration/${self:custom.stage}/warmup/concurrency": 5
 
 provider:
   name: aws

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: "3"
 
 plugins:
   - serverless-plugin-scripts
+  - serverless-offline-ssm
   - serverless-s3-local
   - serverless-stack-termination-protection
   - serverless-iam-helper
@@ -47,6 +48,12 @@ custom:
         # the attachments bucket has no name, so we need to make one up on our own
   serverless-iam-roles-per-function:
     defaultInherit: true
+  serverless-offline-ssm:
+    stages:
+      - local
+    ssm:
+    "/configuration/local/iam/path": "/"
+    "/configuration/local/iam/permissionsBoundaryPolicy": ""
 
 layers:
   clamDefs:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9359,6 +9359,11 @@ serverless-idempotency-helper@CMSgov/serverless-idempotency-helper:
     extract-zip "^2.0.1"
     lodash "^4.17.21"
 
+serverless-offline-ssm@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/serverless-offline-ssm/-/serverless-offline-ssm-6.2.0.tgz#f2db290a72631629579ce5f940ed76f254f96653"
+  integrity sha512-Af7JeLbU4OHAx7ZgAs2OLP2DGKyp/g45rX7SWQ8KiBzn47jme+MqN+GOV6qd5oZ8V9khd3p62+RueHR3ezEZZQ==
+
 serverless-offline@^8.5.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/serverless-offline/-/serverless-offline-8.7.0.tgz#f71205f54cbd23d264f23070eb52f1328e850f51"


### PR DESCRIPTION
## Purpose

This change adds the `serverless-offline-ssm` plugin so that running the Quickstart locally does not require AWS credentials.

#### Linked Issues to Close

## Approach

 The QuickStart already supports local development via the `serverless-offline` and `serverless-local-s3` plugins and the `dev.ts` script. However, when running locally, the `uploads` and `app-api` services can't start because of a dependency on SSM parameters.  

This change adds the [`serverless-offline-ssm`](https://www.serverless.com/plugins/serverless-offline-ssm) plugin to remove this dependency.  The plugin is configured to only take effect for the `local` stage, and provides default values for the SSM variables for the `uploads` and `app-api` services directly, rather than reading them from AWS.   

## Learning

- https://www.serverless.com/plugins/serverless-offline-ssm
- https://www.serverless.com/framework/docs/providers/aws/guide/variables#reference-variables-using-the-ssm-parameter-store


## Assorted Notes/Considerations

Testing:  I ran `dev.ts local` and confirmed that all services started without error, even without AWS credentials in the local environment.

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
