### PR TITLE
Ish client cert

### DIFF
--- a/services/proxy-api/serverless.yml
+++ b/services/proxy-api/serverless.yml
@@ -17,6 +17,7 @@ plugins:
   - serverless-iam-helper
   - serverless-s3-bucket-helper
   - serverless-online
+  - serverless-api-client-certificate
   - serverless-plugin-scripts
   - serverless-iam-roles-per-function
   - "@enterprise-cmcs/serverless-waf-plugin"
@@ -34,6 +35,9 @@ custom:
   associateWaf:
     name: ${self:custom.webAclName}
     version: V2
+  serverlessApiClientCertificate:
+    rotateCerts: true
+    daysLeft: 30
   warmup:
     default:
       enabled: true

--- a/services/proxy-api/serverless.yml
+++ b/services/proxy-api/serverless.yml
@@ -31,7 +31,7 @@ custom:
       - master
       - val
       - production
-  webAclName: ${self:service}-${self:custom.stage}-webacl
+  webAclName: ${self:custom.stage}-${self:service}-webacl
   associateWaf:
     name: ${self:custom.webAclName}
     version: V2


### PR DESCRIPTION
## Purpose
This PR is to resolve APIGateway.4 API Gateway should be associated with a WAF Web ACL and 

APIGateway.2 API Gateway REST API stages should be configured to use SSL certificates for backend authentication security hub findings in the quickstart. 


## Approach

The serverless-api-client-certificate plugin is used to add a client certificate and then rotate the certs every 30 days.
The serverless-associate-waf is used to associate a waf to the api gateway stages.

## Learning
https://www.npmjs.com/package/serverless-api-client-certificate
https://www.serverless.com/plugins/serverless-associate-waf


#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
